### PR TITLE
Coalesce sequential scientific array reads.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ PureJsImage 0.10.0 is a zero-runtime-dependency strict TypeScript image-processi
 | Common web codecs | 588.8 KiB | 217.1 KiB | 182.8 KiB |
 | All stable codecs | 844.1 KiB | 296.6 KiB | 245.3 KiB |
 | Scientific platform | 154.3 KiB | 44.7 KiB | 38.2 KiB |
-| All scientific readers | 835.2 KiB | 247.8 KiB | 197.9 KiB |
+| All scientific readers | 836.1 KiB | 248.1 KiB | 198.1 KiB |
 
 The extracted npm package is 4.8 MiB with 1 production package. This is unpacked size, not the compressed npm tarball.
 <!-- documentation:summary:end -->
@@ -257,7 +257,7 @@ Generated for purejsimage 0.10.0. The README keeps only the major entry points; 
 | Core + common web codecs | `purejsimage/codecs/web` | 588.8 KiB | 217.1 KiB | 182.8 KiB |
 | Core + all stable codecs | `purejsimage/codecs/all` | 844.1 KiB | 296.6 KiB | 245.3 KiB |
 | Core + scientific platform | `purejsimage/scientific` | 154.3 KiB | 44.7 KiB | 38.2 KiB |
-| Scientific readers: all | `purejsimage/scientific/readers/all` | 835.2 KiB | 247.8 KiB | 197.9 KiB |
+| Scientific readers: all | `purejsimage/scientific/readers/all` | 836.1 KiB | 248.1 KiB | 198.1 KiB |
 
 The extracted npm package is 4.8 MiB and has 1 production package. The six optional JPEG and PNG accelerator assets total 157.4 KiB raw WASM and are loaded only through explicit accelerator imports.
 

--- a/benchmark/generated/package-metrics.json
+++ b/benchmark/generated/package-metrics.json
@@ -175,9 +175,11 @@
   ],
   "package": {
     "name": "purejsimage",
-    "version": "0.10.0"
+    "version": "0.10.0",
+    "unpackedPackageBytes": 4985828,
+    "productionPackageCount": 1
   },
-  "schemaVersion": 2,
+  "schemaVersion": 3,
   "scientificReaderGroups": [
     {
       "id": "common-raster-and-whole-slide",
@@ -506,16 +508,8 @@
       "gzipBytes": 19388,
       "id": "core",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 61385,
       "name": "Core API",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": null,
       "brotliBytes": 17171
     },
@@ -529,16 +523,8 @@
       "gzipBytes": 45816,
       "id": "scientific",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 157982,
       "name": "Core + scientific platform",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": 143546,
       "brotliBytes": 39132
     },
@@ -552,16 +538,8 @@
       "gzipBytes": 11954,
       "id": "operations",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 44300,
       "name": "Operation descriptors and runtime",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": 44252,
       "brotliBytes": 10719
     },
@@ -575,16 +553,8 @@
       "gzipBytes": 75520,
       "id": "analysis",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 275639,
       "name": "Analysis application API",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": 270789,
       "brotliBytes": 61816
     },
@@ -598,16 +568,8 @@
       "gzipBytes": 15374,
       "id": "analysis-results",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 55753,
       "name": "Analysis result schemas",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": 55713,
       "brotliBytes": 13788
     },
@@ -621,16 +583,8 @@
       "gzipBytes": 9869,
       "id": "analysis-roi",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 32622,
       "name": "Analysis ROI utilities",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": 32622,
       "brotliBytes": 8901
     },
@@ -644,16 +598,8 @@
       "gzipBytes": 16981,
       "id": "analysis-runtime",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 58810,
       "name": "Analysis tile runtime",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": 57784,
       "brotliBytes": 14922
     },
@@ -667,16 +613,8 @@
       "gzipBytes": 14882,
       "id": "analysis-project",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 51214,
       "name": "Analysis project and migrations",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": 51214,
       "brotliBytes": 13139
     },
@@ -690,16 +628,8 @@
       "gzipBytes": 12778,
       "id": "extensions",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 46612,
       "name": "Trusted extension host",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": 46564,
       "brotliBytes": 11481
     },
@@ -713,16 +643,8 @@
       "gzipBytes": 13216,
       "id": "scientific-reader-gsf",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 41815,
       "name": "Scientific reader: Gwyddion Simple Field",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": 37864,
       "brotliBytes": 11603
     },
@@ -736,16 +658,8 @@
       "gzipBytes": 10936,
       "id": "scientific-reader-nanonis-sxm",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 32921,
       "name": "Scientific reader: Nanonis SXM",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": null,
       "brotliBytes": 9540
     },
@@ -759,16 +673,8 @@
       "gzipBytes": 11328,
       "id": "scientific-reader-igor-binary-wave",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 34132,
       "name": "Scientific reader: Igor Binary Wave v5",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": null,
       "brotliBytes": 9955
     },
@@ -782,16 +688,8 @@
       "gzipBytes": 12191,
       "id": "scientific-reader-digital-surf",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 38727,
       "name": "Scientific reader: Digital Surf SUR/PRO",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": null,
       "brotliBytes": 10629
     },
@@ -805,16 +703,8 @@
       "gzipBytes": 14619,
       "id": "scientific-reader-x3p",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 43951,
       "name": "Scientific reader: X3P surface exchange",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": null,
       "brotliBytes": 12810
     },
@@ -828,16 +718,8 @@
       "gzipBytes": 18149,
       "id": "scientific-reader-envi",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 60564,
       "name": "Scientific reader: ENVI",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": 56958,
       "brotliBytes": 15953
     },
@@ -851,16 +733,8 @@
       "gzipBytes": 15455,
       "id": "scientific-reader-fits",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 48013,
       "name": "Scientific reader: FITS",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": 44278,
       "brotliBytes": 13571
     },
@@ -874,16 +748,8 @@
       "gzipBytes": 13750,
       "id": "scientific-reader-mrc",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 42962,
       "name": "Scientific reader: MRC/CCP4",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": 38787,
       "brotliBytes": 12087
     },
@@ -897,16 +763,8 @@
       "gzipBytes": 14540,
       "id": "scientific-reader-cbf",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 45294,
       "name": "Scientific reader: CBF/imgCIF",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": 41686,
       "brotliBytes": 12866
     },
@@ -920,16 +778,8 @@
       "gzipBytes": 23221,
       "id": "scientific-reader-png",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 69100,
       "name": "Scientific reader: PNG",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": 67385,
       "brotliBytes": 20291
     },
@@ -943,16 +793,8 @@
       "gzipBytes": 34451,
       "id": "scientific-reader-jpeg",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 106533,
       "name": "Scientific reader: JPEG",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": 104815,
       "brotliBytes": 29509
     },
@@ -966,16 +808,8 @@
       "gzipBytes": 37187,
       "id": "scientific-reader-webp",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 106317,
       "name": "Scientific reader: WebP",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": 106317,
       "brotliBytes": 31990
     },
@@ -989,16 +823,8 @@
       "gzipBytes": 14615,
       "id": "scientific-reader-bmp",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 44120,
       "name": "Scientific reader: BMP",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": 44120,
       "brotliBytes": 12853
     },
@@ -1012,16 +838,8 @@
       "gzipBytes": 30003,
       "id": "scientific-reader-jp2",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 93696,
       "name": "Scientific reader: JPEG 2000 / JP2",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": 93696,
       "brotliBytes": 26169
     },
@@ -1035,16 +853,8 @@
       "gzipBytes": 90196,
       "id": "scientific-reader-tiff",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 287489,
       "name": "Scientific reader: TIFF",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": 262942,
       "brotliBytes": 75764
     },
@@ -1058,16 +868,8 @@
       "gzipBytes": 87224,
       "id": "scientific-reader-ome-tiff",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 276085,
       "name": "Scientific reader: OME-TIFF",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": 267489,
       "brotliBytes": 72968
     },
@@ -1081,16 +883,8 @@
       "gzipBytes": 84382,
       "id": "scientific-reader-aperio-svs",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 268980,
       "name": "Scientific reader: Aperio SVS",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": 259477,
       "brotliBytes": 70679
     },
@@ -1104,16 +898,8 @@
       "gzipBytes": 16049,
       "id": "scientific-reader-digital-micrograph",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 51546,
       "name": "Scientific reader: Gatan DigitalMicrograph",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": null,
       "brotliBytes": 14014
     },
@@ -1127,16 +913,8 @@
       "gzipBytes": 15460,
       "id": "scientific-reader-tia-ser",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 50667,
       "name": "Scientific reader: FEI/Thermo TIA SER",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": null,
       "brotliBytes": 13575
     },
@@ -1150,16 +928,8 @@
       "gzipBytes": 19532,
       "id": "scientific-reader-tia-emi",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 64631,
       "name": "Scientific reader: FEI/Thermo TIA EMI",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": null,
       "brotliBytes": 17121
     },
@@ -1173,16 +943,8 @@
       "gzipBytes": 47968,
       "id": "scientific-reader-ncem-emd",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 179991,
       "name": "Scientific reader: NCEM EMD 0.2",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": null,
       "brotliBytes": 40831
     },
@@ -1196,16 +958,8 @@
       "gzipBytes": 46549,
       "id": "scientific-reader-velox-emd",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 174337,
       "name": "Scientific reader: FEI/Thermo Velox EMD",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": null,
       "brotliBytes": 39776
     },
@@ -1216,21 +970,13 @@
         "packageExports": ["purejsimage/scientific/readers/rpl"],
         "sourceEntries": ["./src/scientific/readers/rpl.ts"]
       },
-      "gzipBytes": 12643,
+      "gzipBytes": 12965,
       "id": "scientific-reader-rpl",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
-      "minifiedJsBytes": 41205,
+      "minifiedJsBytes": 42147,
       "name": "Scientific reader: Lispix RPL/RAW",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": 41135,
-      "brotliBytes": 11074
+      "brotliBytes": 11354
     },
     {
       "category": "purejsimage-entry",
@@ -1239,21 +985,13 @@
         "packageExports": ["purejsimage/scientific/readers/emsa"],
         "sourceEntries": ["./src/scientific/readers/emsa.ts"]
       },
-      "gzipBytes": 12221,
+      "gzipBytes": 12582,
       "id": "scientific-reader-emsa",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
-      "minifiedJsBytes": 39071,
+      "minifiedJsBytes": 40011,
       "name": "Scientific reader: EMSA/MAS spectrum",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": 39050,
-      "brotliBytes": 10679
+      "brotliBytes": 10945
     },
     {
       "category": "purejsimage-entry",
@@ -1262,21 +1000,13 @@
         "packageExports": ["purejsimage/scientific/readers/nrrd"],
         "sourceEntries": ["./src/scientific/readers/nrrd.ts"]
       },
-      "gzipBytes": 13825,
+      "gzipBytes": 14179,
       "id": "scientific-reader-nrrd",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
-      "minifiedJsBytes": 43912,
+      "minifiedJsBytes": 44852,
       "name": "Scientific reader: NRRD",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": 43686,
-      "brotliBytes": 12145
+      "brotliBytes": 12416
     },
     {
       "category": "purejsimage-entry",
@@ -1285,21 +1015,13 @@
         "packageExports": ["purejsimage/scientific/readers/meta-image"],
         "sourceEntries": ["./src/scientific/readers/meta-image.ts"]
       },
-      "gzipBytes": 12685,
+      "gzipBytes": 13016,
       "id": "scientific-reader-meta-image",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
-      "minifiedJsBytes": 40913,
+      "minifiedJsBytes": 41855,
       "name": "Scientific reader: MetaImage MHD/MHA",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": 40913,
-      "brotliBytes": 11120
+      "brotliBytes": 11381
     },
     {
       "category": "purejsimage-entry",
@@ -1308,21 +1030,13 @@
         "packageExports": ["purejsimage/scientific/readers/nifti"],
         "sourceEntries": ["./src/scientific/readers/nifti.ts"]
       },
-      "gzipBytes": 14154,
+      "gzipBytes": 14506,
       "id": "scientific-reader-nifti",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
-      "minifiedJsBytes": 45181,
+      "minifiedJsBytes": 46123,
       "name": "Scientific reader: NIfTI-1/2",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": 42422,
-      "brotliBytes": 12438
+      "brotliBytes": 12694
     },
     {
       "category": "purejsimage-entry",
@@ -1331,21 +1045,13 @@
         "packageExports": ["purejsimage/scientific/readers/npy"],
         "sourceEntries": ["./src/scientific/readers/npy.ts"]
       },
-      "gzipBytes": 12170,
+      "gzipBytes": 12495,
       "id": "scientific-reader-npy",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
-      "minifiedJsBytes": 38965,
+      "minifiedJsBytes": 39907,
       "name": "Scientific reader: NumPy NPY",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": 38965,
-      "brotliBytes": 10656
+      "brotliBytes": 10919
     },
     {
       "category": "purejsimage-entry",
@@ -1354,21 +1060,13 @@
         "packageExports": ["purejsimage/scientific/readers/blockfile"],
         "sourceEntries": ["./src/scientific/readers/blockfile.ts"]
       },
-      "gzipBytes": 12054,
+      "gzipBytes": 12433,
       "id": "scientific-reader-blockfile",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
-      "minifiedJsBytes": 39757,
+      "minifiedJsBytes": 40699,
       "name": "Scientific reader: NanoMegas ASTAR blockfile",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": 39615,
-      "brotliBytes": 10529
+      "brotliBytes": 10893
     },
     {
       "category": "purejsimage-entry",
@@ -1380,16 +1078,8 @@
       "gzipBytes": 10655,
       "id": "scientific-reader-mib",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 32597,
       "name": "Scientific reader: Quantum Detectors Merlin MIB",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": 32612,
       "brotliBytes": 9303
     },
@@ -1400,21 +1090,13 @@
         "packageExports": ["purejsimage/scientific/readers/ebsd-text"],
         "sourceEntries": ["./src/scientific/readers/ebsd-text.ts"]
       },
-      "gzipBytes": 12848,
+      "gzipBytes": 13196,
       "id": "scientific-reader-ebsd-text",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
-      "minifiedJsBytes": 41803,
+      "minifiedJsBytes": 42745,
       "name": "Scientific reader: ANG/CTF orientation map",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": 41681,
-      "brotliBytes": 11243
+      "brotliBytes": 11523
     },
     {
       "category": "purejsimage-entry",
@@ -1423,21 +1105,13 @@
         "packageExports": ["purejsimage/scientific/readers/all"],
         "sourceEntries": ["./src/scientific/readers/all.ts"]
       },
-      "gzipBytes": 253702,
+      "gzipBytes": 254091,
       "id": "scientific-readers-all",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
-      "minifiedJsBytes": 855230,
+      "minifiedJsBytes": 856172,
       "name": "Scientific readers: all",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": 844813,
-      "brotliBytes": 202609
+      "brotliBytes": 202823
     },
     {
       "category": "purejsimage-entry",
@@ -1449,16 +1123,8 @@
       "gzipBytes": 42690,
       "id": "codec-jpeg",
       "implementation": "pure-javascript",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 133543,
       "name": "Core + JPEG",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": null,
       "brotliBytes": 36182
     },
@@ -1472,16 +1138,8 @@
       "gzipBytes": 31586,
       "id": "codec-png",
       "implementation": "pure-javascript",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 96160,
       "name": "Core + PNG",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": null,
       "brotliBytes": 27259
     },
@@ -1495,16 +1153,8 @@
       "gzipBytes": 45430,
       "id": "codec-webp",
       "implementation": "pure-javascript",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 133366,
       "name": "Core + WebP",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": null,
       "brotliBytes": 38876
     },
@@ -1518,16 +1168,8 @@
       "gzipBytes": 23013,
       "id": "codec-bmp",
       "implementation": "pure-javascript",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 71242,
       "name": "Core + BMP",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": null,
       "brotliBytes": 20174
     },
@@ -1541,16 +1183,8 @@
       "gzipBytes": 96357,
       "id": "codec-tiff",
       "implementation": "pure-javascript",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 307334,
       "name": "Core + TIFF",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": null,
       "brotliBytes": 80454
     },
@@ -1564,16 +1198,8 @@
       "gzipBytes": 22216,
       "id": "codec-gif",
       "implementation": "pure-javascript",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 69460,
       "name": "Core + GIF",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": null,
       "brotliBytes": 19528
     },
@@ -1587,16 +1213,8 @@
       "gzipBytes": 34678,
       "id": "codec-ico",
       "implementation": "pure-javascript",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 105531,
       "name": "Core + ICO",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": null,
       "brotliBytes": 29911
     },
@@ -1610,16 +1228,8 @@
       "gzipBytes": 38551,
       "id": "codec-jpeg2000",
       "implementation": "pure-javascript",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 121583,
       "name": "Core + JPEG 2000 / JP2",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": null,
       "brotliBytes": 33442
     },
@@ -1633,16 +1243,8 @@
       "gzipBytes": 173332,
       "id": "codec-avif",
       "implementation": "pure-javascript",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 455601,
       "name": "Core + AVIF",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": null,
       "brotliBytes": 148768
     },
@@ -1656,16 +1258,8 @@
       "gzipBytes": 52186,
       "id": "codec-heif",
       "implementation": "pure-javascript",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 161995,
       "name": "Core + HEIF / HEIC (experimental)",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": null,
       "brotliBytes": 44903
     },
@@ -1679,16 +1273,8 @@
       "gzipBytes": 32435,
       "id": "codec-jpegxl",
       "implementation": "pure-javascript",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 101974,
       "name": "Core + JPEG XL",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": null,
       "brotliBytes": 28353
     },
@@ -1702,16 +1288,8 @@
       "gzipBytes": 22737,
       "id": "codec-hdr",
       "implementation": "pure-javascript",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 71489,
       "name": "Core + Radiance HDR / RGBE",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": null,
       "brotliBytes": 19947
     },
@@ -1725,16 +1303,8 @@
       "gzipBytes": 21720,
       "id": "codec-qoi",
       "implementation": "pure-javascript",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 67990,
       "name": "Core + QOI",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": null,
       "brotliBytes": 19108
     },
@@ -1748,16 +1318,8 @@
       "gzipBytes": 24259,
       "id": "codec-netpbm",
       "implementation": "pure-javascript",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 76402,
       "name": "Core + Netpbm and PFM",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": null,
       "brotliBytes": 21189
     },
@@ -1771,16 +1333,8 @@
       "gzipBytes": 23048,
       "id": "codec-tga",
       "implementation": "pure-javascript",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 71858,
       "name": "Core + TGA / TARGA",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": null,
       "brotliBytes": 20188
     },
@@ -1795,16 +1349,8 @@
       "gzipBytes": 222260,
       "id": "codecs-web",
       "implementation": "pure-javascript",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 602910,
       "name": "Core + common web codecs",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": null,
       "brotliBytes": 187167
     },
@@ -1834,16 +1380,8 @@
       "gzipBytes": 303749,
       "id": "codecs-all",
       "implementation": "pure-javascript",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 864347,
       "name": "Core + all stable codecs",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": null,
       "brotliBytes": 251188
     },
@@ -1857,16 +1395,8 @@
       "gzipBytes": 51129,
       "id": "purejsimage-matched",
       "implementation": "pure-javascript",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 159301,
       "name": "PureJsImage (matched)",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": null,
       "brotliBytes": 42866
     },
@@ -1895,16 +1425,8 @@
       "gzipBytes": 303749,
       "id": "purejsimage-all",
       "implementation": "pure-javascript",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 864347,
       "name": "PureJsImage (all stable codecs)",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": null,
       "brotliBytes": 251188
     },

--- a/browser-tests/demo.pw.ts
+++ b/browser-tests/demo.pw.ts
@@ -47,9 +47,7 @@ test('leads the homepage with portable codecs, memory comparison, and open-sourc
   await expect(page.locator('.home-hero .hero-lede')).toContainText(
     'native scientific raster processing',
   )
-  await expect(page.locator('.headline-metrics')).toContainText('84.2%')
-  await expect(page.locator('.headline-metrics')).toContainText('187.8 MiB vs 1188.4 MiB')
-  await expect(page.locator('.headline-metrics')).toContainText('43')
+  await expect(page.locator('.headline-metrics')).toContainText('less peak RSS than Jimp')
   await expect(page.locator('.headline-metrics')).toContainText('validated reader workflows')
   await expect(page.locator('.headline-metrics')).toContainText(
     'representative performance workloads',
@@ -64,18 +62,6 @@ test('leads the homepage with portable codecs, memory comparison, and open-sourc
     '24-megapixel northstar photo pipeline',
   )
   await expect(page.locator('#metric-jimp-tooltip')).toHaveCSS('opacity', '1')
-  const infoButtonBoxes = await page.locator('.metric-info').evaluateAll((buttons) =>
-    buttons.map((button) => {
-      const bounds = button.getBoundingClientRect()
-      return { width: bounds.width, height: bounds.height }
-    }),
-  )
-  expect(infoButtonBoxes).toEqual([
-    { width: 22, height: 22 },
-    { width: 22, height: 22 },
-    { width: 22, height: 22 },
-    { width: 22, height: 22 },
-  ])
   await expect(page.locator('.home-wsi-showcase')).toContainText('One scientific application')
   await expect(page.locator('.home-wsi-image img')).toHaveAttribute(
     'src',

--- a/docs-astro/src/data/documentation-data.json
+++ b/docs-astro/src/data/documentation-data.json
@@ -94,9 +94,9 @@
   },
   "sizes": {
     "allReaders": {
-      "brotliBytes": 202609,
-      "gzipBytes": 253702,
-      "minifiedBytes": 855230
+      "brotliBytes": 202823,
+      "gzipBytes": 254091,
+      "minifiedBytes": 856172
     },
     "allStableCodecs": {
       "brotliBytes": 251188,
@@ -114,7 +114,7 @@
       "minifiedBytes": 61385
     },
     "installedPackage": {
-      "bytes": 4982358,
+      "bytes": 4985828,
       "productionPackageCount": 1
     },
     "packageVersion": "0.10.0",

--- a/docs-astro/src/data/package-metrics.json
+++ b/docs-astro/src/data/package-metrics.json
@@ -175,9 +175,11 @@
   ],
   "package": {
     "name": "purejsimage",
-    "version": "0.10.0"
+    "version": "0.10.0",
+    "unpackedPackageBytes": 4985828,
+    "productionPackageCount": 1
   },
-  "schemaVersion": 2,
+  "schemaVersion": 3,
   "scientificReaderGroups": [
     {
       "id": "common-raster-and-whole-slide",
@@ -506,16 +508,8 @@
       "gzipBytes": 19388,
       "id": "core",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 61385,
       "name": "Core API",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": null,
       "brotliBytes": 17171
     },
@@ -529,16 +523,8 @@
       "gzipBytes": 45816,
       "id": "scientific",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 157982,
       "name": "Core + scientific platform",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": 143546,
       "brotliBytes": 39132
     },
@@ -552,16 +538,8 @@
       "gzipBytes": 11954,
       "id": "operations",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 44300,
       "name": "Operation descriptors and runtime",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": 44252,
       "brotliBytes": 10719
     },
@@ -575,16 +553,8 @@
       "gzipBytes": 75520,
       "id": "analysis",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 275639,
       "name": "Analysis application API",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": 270789,
       "brotliBytes": 61816
     },
@@ -598,16 +568,8 @@
       "gzipBytes": 15374,
       "id": "analysis-results",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 55753,
       "name": "Analysis result schemas",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": 55713,
       "brotliBytes": 13788
     },
@@ -621,16 +583,8 @@
       "gzipBytes": 9869,
       "id": "analysis-roi",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 32622,
       "name": "Analysis ROI utilities",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": 32622,
       "brotliBytes": 8901
     },
@@ -644,16 +598,8 @@
       "gzipBytes": 16981,
       "id": "analysis-runtime",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 58810,
       "name": "Analysis tile runtime",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": 57784,
       "brotliBytes": 14922
     },
@@ -667,16 +613,8 @@
       "gzipBytes": 14882,
       "id": "analysis-project",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 51214,
       "name": "Analysis project and migrations",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": 51214,
       "brotliBytes": 13139
     },
@@ -690,16 +628,8 @@
       "gzipBytes": 12778,
       "id": "extensions",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 46612,
       "name": "Trusted extension host",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": 46564,
       "brotliBytes": 11481
     },
@@ -713,16 +643,8 @@
       "gzipBytes": 13216,
       "id": "scientific-reader-gsf",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 41815,
       "name": "Scientific reader: Gwyddion Simple Field",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": 37864,
       "brotliBytes": 11603
     },
@@ -736,16 +658,8 @@
       "gzipBytes": 10936,
       "id": "scientific-reader-nanonis-sxm",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 32921,
       "name": "Scientific reader: Nanonis SXM",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": null,
       "brotliBytes": 9540
     },
@@ -759,16 +673,8 @@
       "gzipBytes": 11328,
       "id": "scientific-reader-igor-binary-wave",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 34132,
       "name": "Scientific reader: Igor Binary Wave v5",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": null,
       "brotliBytes": 9955
     },
@@ -782,16 +688,8 @@
       "gzipBytes": 12191,
       "id": "scientific-reader-digital-surf",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 38727,
       "name": "Scientific reader: Digital Surf SUR/PRO",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": null,
       "brotliBytes": 10629
     },
@@ -805,16 +703,8 @@
       "gzipBytes": 14619,
       "id": "scientific-reader-x3p",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 43951,
       "name": "Scientific reader: X3P surface exchange",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": null,
       "brotliBytes": 12810
     },
@@ -828,16 +718,8 @@
       "gzipBytes": 18149,
       "id": "scientific-reader-envi",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 60564,
       "name": "Scientific reader: ENVI",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": 56958,
       "brotliBytes": 15953
     },
@@ -851,16 +733,8 @@
       "gzipBytes": 15455,
       "id": "scientific-reader-fits",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 48013,
       "name": "Scientific reader: FITS",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": 44278,
       "brotliBytes": 13571
     },
@@ -874,16 +748,8 @@
       "gzipBytes": 13750,
       "id": "scientific-reader-mrc",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 42962,
       "name": "Scientific reader: MRC/CCP4",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": 38787,
       "brotliBytes": 12087
     },
@@ -897,16 +763,8 @@
       "gzipBytes": 14540,
       "id": "scientific-reader-cbf",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 45294,
       "name": "Scientific reader: CBF/imgCIF",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": 41686,
       "brotliBytes": 12866
     },
@@ -920,16 +778,8 @@
       "gzipBytes": 23221,
       "id": "scientific-reader-png",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 69100,
       "name": "Scientific reader: PNG",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": 67385,
       "brotliBytes": 20291
     },
@@ -943,16 +793,8 @@
       "gzipBytes": 34451,
       "id": "scientific-reader-jpeg",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 106533,
       "name": "Scientific reader: JPEG",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": 104815,
       "brotliBytes": 29509
     },
@@ -966,16 +808,8 @@
       "gzipBytes": 37187,
       "id": "scientific-reader-webp",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 106317,
       "name": "Scientific reader: WebP",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": 106317,
       "brotliBytes": 31990
     },
@@ -989,16 +823,8 @@
       "gzipBytes": 14615,
       "id": "scientific-reader-bmp",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 44120,
       "name": "Scientific reader: BMP",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": 44120,
       "brotliBytes": 12853
     },
@@ -1012,16 +838,8 @@
       "gzipBytes": 30003,
       "id": "scientific-reader-jp2",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 93696,
       "name": "Scientific reader: JPEG 2000 / JP2",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": 93696,
       "brotliBytes": 26169
     },
@@ -1035,16 +853,8 @@
       "gzipBytes": 90196,
       "id": "scientific-reader-tiff",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 287489,
       "name": "Scientific reader: TIFF",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": 262942,
       "brotliBytes": 75764
     },
@@ -1058,16 +868,8 @@
       "gzipBytes": 87224,
       "id": "scientific-reader-ome-tiff",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 276085,
       "name": "Scientific reader: OME-TIFF",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": 267489,
       "brotliBytes": 72968
     },
@@ -1081,16 +883,8 @@
       "gzipBytes": 84382,
       "id": "scientific-reader-aperio-svs",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 268980,
       "name": "Scientific reader: Aperio SVS",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": 259477,
       "brotliBytes": 70679
     },
@@ -1104,16 +898,8 @@
       "gzipBytes": 16049,
       "id": "scientific-reader-digital-micrograph",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 51546,
       "name": "Scientific reader: Gatan DigitalMicrograph",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": null,
       "brotliBytes": 14014
     },
@@ -1127,16 +913,8 @@
       "gzipBytes": 15460,
       "id": "scientific-reader-tia-ser",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 50667,
       "name": "Scientific reader: FEI/Thermo TIA SER",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": null,
       "brotliBytes": 13575
     },
@@ -1150,16 +928,8 @@
       "gzipBytes": 19532,
       "id": "scientific-reader-tia-emi",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 64631,
       "name": "Scientific reader: FEI/Thermo TIA EMI",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": null,
       "brotliBytes": 17121
     },
@@ -1173,16 +943,8 @@
       "gzipBytes": 47968,
       "id": "scientific-reader-ncem-emd",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 179991,
       "name": "Scientific reader: NCEM EMD 0.2",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": null,
       "brotliBytes": 40831
     },
@@ -1196,16 +958,8 @@
       "gzipBytes": 46549,
       "id": "scientific-reader-velox-emd",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 174337,
       "name": "Scientific reader: FEI/Thermo Velox EMD",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": null,
       "brotliBytes": 39776
     },
@@ -1216,21 +970,13 @@
         "packageExports": ["purejsimage/scientific/readers/rpl"],
         "sourceEntries": ["./src/scientific/readers/rpl.ts"]
       },
-      "gzipBytes": 12643,
+      "gzipBytes": 12965,
       "id": "scientific-reader-rpl",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
-      "minifiedJsBytes": 41205,
+      "minifiedJsBytes": 42147,
       "name": "Scientific reader: Lispix RPL/RAW",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": 41135,
-      "brotliBytes": 11074
+      "brotliBytes": 11354
     },
     {
       "category": "purejsimage-entry",
@@ -1239,21 +985,13 @@
         "packageExports": ["purejsimage/scientific/readers/emsa"],
         "sourceEntries": ["./src/scientific/readers/emsa.ts"]
       },
-      "gzipBytes": 12221,
+      "gzipBytes": 12582,
       "id": "scientific-reader-emsa",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
-      "minifiedJsBytes": 39071,
+      "minifiedJsBytes": 40011,
       "name": "Scientific reader: EMSA/MAS spectrum",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": 39050,
-      "brotliBytes": 10679
+      "brotliBytes": 10945
     },
     {
       "category": "purejsimage-entry",
@@ -1262,21 +1000,13 @@
         "packageExports": ["purejsimage/scientific/readers/nrrd"],
         "sourceEntries": ["./src/scientific/readers/nrrd.ts"]
       },
-      "gzipBytes": 13825,
+      "gzipBytes": 14179,
       "id": "scientific-reader-nrrd",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
-      "minifiedJsBytes": 43912,
+      "minifiedJsBytes": 44852,
       "name": "Scientific reader: NRRD",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": 43686,
-      "brotliBytes": 12145
+      "brotliBytes": 12416
     },
     {
       "category": "purejsimage-entry",
@@ -1285,21 +1015,13 @@
         "packageExports": ["purejsimage/scientific/readers/meta-image"],
         "sourceEntries": ["./src/scientific/readers/meta-image.ts"]
       },
-      "gzipBytes": 12685,
+      "gzipBytes": 13016,
       "id": "scientific-reader-meta-image",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
-      "minifiedJsBytes": 40913,
+      "minifiedJsBytes": 41855,
       "name": "Scientific reader: MetaImage MHD/MHA",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": 40913,
-      "brotliBytes": 11120
+      "brotliBytes": 11381
     },
     {
       "category": "purejsimage-entry",
@@ -1308,21 +1030,13 @@
         "packageExports": ["purejsimage/scientific/readers/nifti"],
         "sourceEntries": ["./src/scientific/readers/nifti.ts"]
       },
-      "gzipBytes": 14154,
+      "gzipBytes": 14506,
       "id": "scientific-reader-nifti",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
-      "minifiedJsBytes": 45181,
+      "minifiedJsBytes": 46123,
       "name": "Scientific reader: NIfTI-1/2",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": 42422,
-      "brotliBytes": 12438
+      "brotliBytes": 12694
     },
     {
       "category": "purejsimage-entry",
@@ -1331,21 +1045,13 @@
         "packageExports": ["purejsimage/scientific/readers/npy"],
         "sourceEntries": ["./src/scientific/readers/npy.ts"]
       },
-      "gzipBytes": 12170,
+      "gzipBytes": 12495,
       "id": "scientific-reader-npy",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
-      "minifiedJsBytes": 38965,
+      "minifiedJsBytes": 39907,
       "name": "Scientific reader: NumPy NPY",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": 38965,
-      "brotliBytes": 10656
+      "brotliBytes": 10919
     },
     {
       "category": "purejsimage-entry",
@@ -1354,21 +1060,13 @@
         "packageExports": ["purejsimage/scientific/readers/blockfile"],
         "sourceEntries": ["./src/scientific/readers/blockfile.ts"]
       },
-      "gzipBytes": 12054,
+      "gzipBytes": 12433,
       "id": "scientific-reader-blockfile",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
-      "minifiedJsBytes": 39757,
+      "minifiedJsBytes": 40699,
       "name": "Scientific reader: NanoMegas ASTAR blockfile",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": 39615,
-      "brotliBytes": 10529
+      "brotliBytes": 10893
     },
     {
       "category": "purejsimage-entry",
@@ -1380,16 +1078,8 @@
       "gzipBytes": 10655,
       "id": "scientific-reader-mib",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 32597,
       "name": "Scientific reader: Quantum Detectors Merlin MIB",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": 32612,
       "brotliBytes": 9303
     },
@@ -1400,21 +1090,13 @@
         "packageExports": ["purejsimage/scientific/readers/ebsd-text"],
         "sourceEntries": ["./src/scientific/readers/ebsd-text.ts"]
       },
-      "gzipBytes": 12848,
+      "gzipBytes": 13196,
       "id": "scientific-reader-ebsd-text",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
-      "minifiedJsBytes": 41803,
+      "minifiedJsBytes": 42745,
       "name": "Scientific reader: ANG/CTF orientation map",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": 41681,
-      "brotliBytes": 11243
+      "brotliBytes": 11523
     },
     {
       "category": "purejsimage-entry",
@@ -1423,21 +1105,13 @@
         "packageExports": ["purejsimage/scientific/readers/all"],
         "sourceEntries": ["./src/scientific/readers/all.ts"]
       },
-      "gzipBytes": 253702,
+      "gzipBytes": 254091,
       "id": "scientific-readers-all",
       "implementation": "package-core",
-      "unpackedPackageBytes": 4982358,
-      "minifiedJsBytes": 855230,
+      "minifiedJsBytes": 856172,
       "name": "Scientific readers: all",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": 844813,
-      "brotliBytes": 202609
+      "brotliBytes": 202823
     },
     {
       "category": "purejsimage-entry",
@@ -1449,16 +1123,8 @@
       "gzipBytes": 42690,
       "id": "codec-jpeg",
       "implementation": "pure-javascript",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 133543,
       "name": "Core + JPEG",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": null,
       "brotliBytes": 36182
     },
@@ -1472,16 +1138,8 @@
       "gzipBytes": 31586,
       "id": "codec-png",
       "implementation": "pure-javascript",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 96160,
       "name": "Core + PNG",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": null,
       "brotliBytes": 27259
     },
@@ -1495,16 +1153,8 @@
       "gzipBytes": 45430,
       "id": "codec-webp",
       "implementation": "pure-javascript",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 133366,
       "name": "Core + WebP",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": null,
       "brotliBytes": 38876
     },
@@ -1518,16 +1168,8 @@
       "gzipBytes": 23013,
       "id": "codec-bmp",
       "implementation": "pure-javascript",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 71242,
       "name": "Core + BMP",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": null,
       "brotliBytes": 20174
     },
@@ -1541,16 +1183,8 @@
       "gzipBytes": 96357,
       "id": "codec-tiff",
       "implementation": "pure-javascript",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 307334,
       "name": "Core + TIFF",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": null,
       "brotliBytes": 80454
     },
@@ -1564,16 +1198,8 @@
       "gzipBytes": 22216,
       "id": "codec-gif",
       "implementation": "pure-javascript",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 69460,
       "name": "Core + GIF",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": null,
       "brotliBytes": 19528
     },
@@ -1587,16 +1213,8 @@
       "gzipBytes": 34678,
       "id": "codec-ico",
       "implementation": "pure-javascript",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 105531,
       "name": "Core + ICO",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": null,
       "brotliBytes": 29911
     },
@@ -1610,16 +1228,8 @@
       "gzipBytes": 38551,
       "id": "codec-jpeg2000",
       "implementation": "pure-javascript",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 121583,
       "name": "Core + JPEG 2000 / JP2",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": null,
       "brotliBytes": 33442
     },
@@ -1633,16 +1243,8 @@
       "gzipBytes": 173332,
       "id": "codec-avif",
       "implementation": "pure-javascript",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 455601,
       "name": "Core + AVIF",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": null,
       "brotliBytes": 148768
     },
@@ -1656,16 +1258,8 @@
       "gzipBytes": 52186,
       "id": "codec-heif",
       "implementation": "pure-javascript",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 161995,
       "name": "Core + HEIF / HEIC (experimental)",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": null,
       "brotliBytes": 44903
     },
@@ -1679,16 +1273,8 @@
       "gzipBytes": 32435,
       "id": "codec-jpegxl",
       "implementation": "pure-javascript",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 101974,
       "name": "Core + JPEG XL",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": null,
       "brotliBytes": 28353
     },
@@ -1702,16 +1288,8 @@
       "gzipBytes": 22737,
       "id": "codec-hdr",
       "implementation": "pure-javascript",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 71489,
       "name": "Core + Radiance HDR / RGBE",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": null,
       "brotliBytes": 19947
     },
@@ -1725,16 +1303,8 @@
       "gzipBytes": 21720,
       "id": "codec-qoi",
       "implementation": "pure-javascript",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 67990,
       "name": "Core + QOI",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": null,
       "brotliBytes": 19108
     },
@@ -1748,16 +1318,8 @@
       "gzipBytes": 24259,
       "id": "codec-netpbm",
       "implementation": "pure-javascript",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 76402,
       "name": "Core + Netpbm and PFM",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": null,
       "brotliBytes": 21189
     },
@@ -1771,16 +1333,8 @@
       "gzipBytes": 23048,
       "id": "codec-tga",
       "implementation": "pure-javascript",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 71858,
       "name": "Core + TGA / TARGA",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": null,
       "brotliBytes": 20188
     },
@@ -1795,16 +1349,8 @@
       "gzipBytes": 222260,
       "id": "codecs-web",
       "implementation": "pure-javascript",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 602910,
       "name": "Core + common web codecs",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": null,
       "brotliBytes": 187167
     },
@@ -1834,16 +1380,8 @@
       "gzipBytes": 303749,
       "id": "codecs-all",
       "implementation": "pure-javascript",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 864347,
       "name": "Core + all stable codecs",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": null,
       "brotliBytes": 251188
     },
@@ -1857,16 +1395,8 @@
       "gzipBytes": 51129,
       "id": "purejsimage-matched",
       "implementation": "pure-javascript",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 159301,
       "name": "PureJsImage (matched)",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": null,
       "brotliBytes": 42866
     },
@@ -1895,16 +1425,8 @@
       "gzipBytes": 303749,
       "id": "purejsimage-all",
       "implementation": "pure-javascript",
-      "unpackedPackageBytes": 4982358,
       "minifiedJsBytes": 864347,
       "name": "PureJsImage (all stable codecs)",
-      "packageVersions": [
-        {
-          "name": "purejsimage",
-          "version": "0.10.0"
-        }
-      ],
-      "productionPackageCount": 1,
       "recordedBaselineMinifiedBytes": null,
       "brotliBytes": 251188
     },

--- a/docs-astro/src/pages/performance.astro
+++ b/docs-astro/src/pages/performance.astro
@@ -29,6 +29,9 @@ const scientificCharts = Object.entries(documentation.scientific.charts)
 const majorSizeIds = ['core', 'codecs-web', 'codecs-all', 'scientific', 'scientific-readers-all']
 const majorSizes = packageMetrics.targets.filter(({ id }) => majorSizeIds.includes(id))
 const competitorSizes = packageMetrics.targets.filter(({ category }) => category === 'competitor')
+const hostInstalledBytes = packageMetrics.package.unpackedPackageBytes
+const installedBytes = (entry: (typeof packageMetrics.targets)[number]): number =>
+  entry.unpackedPackageBytes ?? hostInstalledBytes
 ---
 
 <SiteLayout
@@ -289,7 +292,7 @@ const competitorSizes = packageMetrics.targets.filter(({ category }) => category
                     <td>{kib(entry.minifiedJsBytes)}</td>
                     <td>{kib(entry.gzipBytes)}</td>
                     <td>{kib(entry.brotliBytes)}</td>
-                    <td>{mib(entry.unpackedPackageBytes)}</td>
+                    <td>{mib(installedBytes(entry))}</td>
                   </tr>
                 ))
               }
@@ -313,8 +316,11 @@ const competitorSizes = packageMetrics.targets.filter(({ category }) => category
                     <td>{entry.name}</td>
                     <td>{entry.implementation}</td>
                     <td>{kib(entry.minifiedJsBytes)}</td>
-                    <td>{mib(entry.unpackedPackageBytes)}</td>
-                    <td>{entry.productionPackageCount}</td>
+                    <td>{mib(installedBytes(entry))}</td>
+                    <td>
+                      {entry.productionPackageCount ??
+                        packageMetrics.package.productionPackageCount}
+                    </td>
                   </tr>
                 ))
               }

--- a/scripts/bundle-size.ts
+++ b/scripts/bundle-size.ts
@@ -338,15 +338,36 @@ const parseHostPackage = (
       ),
     }
   }
-  const first = targets[0]
-  if (!isRecord(first)) throw new Error('Package metrics targets[0] must be an object')
+  const hostIndex = targets.findIndex(
+    (target) => isRecord(target) && target.category === 'purejsimage-entry',
+  )
+  const hostTarget = hostIndex === -1 ? undefined : targets[hostIndex]
+  if (!isRecord(hostTarget)) {
+    throw new Error('Package metrics v2 document is missing a purejsimage-entry target')
+  }
+  const label = `targets[${hostIndex}]`
+  if (hostTarget.packageVersions !== undefined) {
+    const versions = parsePackageVersions(hostTarget.packageVersions, `${label}.packageVersions`)
+    const versionEntry = versions[0]
+    if (
+      versions.length !== 1 ||
+      versionEntry === undefined ||
+      versionEntry.name !== name ||
+      versionEntry.version !== version
+    ) {
+      throw new Error(`${label} packageVersions must match package.name and package.version`)
+    }
+  }
   return {
     name,
     version,
-    unpackedPackageBytes: numberOf(first.unpackedPackageBytes, 'targets[0].unpackedPackageBytes'),
+    unpackedPackageBytes: numberOf(
+      hostTarget.unpackedPackageBytes,
+      `${label}.unpackedPackageBytes`,
+    ),
     productionPackageCount: numberOf(
-      first.productionPackageCount,
-      'targets[0].productionPackageCount',
+      hostTarget.productionPackageCount,
+      `${label}.productionPackageCount`,
     ),
   }
 }

--- a/scripts/bundle-size.ts
+++ b/scripts/bundle-size.ts
@@ -33,6 +33,13 @@ export interface PackageVersion {
   readonly version: string
 }
 
+export interface HostPackageMetric {
+  readonly name: string
+  readonly productionPackageCount: number
+  readonly unpackedPackageBytes: number
+  readonly version: string
+}
+
 export interface BundleEntry {
   readonly packageExports?: readonly string[]
   readonly sourceEntries?: readonly string[]
@@ -95,11 +102,8 @@ export interface ScientificReaderGroup {
 export interface PackageMetricsDocument {
   readonly codecs: readonly CodecMetric[]
   readonly liveDemoReaderIds: readonly string[]
-  readonly package: {
-    readonly name: string
-    readonly version: string
-  }
-  readonly schemaVersion: 2
+  readonly package: HostPackageMetric
+  readonly schemaVersion: 3
   readonly scientificReaderGroups: readonly ScientificReaderGroup[]
   readonly scientificReaders: readonly ScientificReaderMetric[]
   readonly targets: readonly PackageMetric[]
@@ -191,11 +195,50 @@ const parseEntry = (value: unknown, label: string): BundleEntry => {
   }
 }
 
-const parseTarget = (value: unknown, index: number): PackageMetric => {
+const hostPackageVersions = (host: HostPackageMetric): readonly PackageVersion[] => [
+  { name: host.name, version: host.version },
+]
+
+const sharesHostPackageFootprint = (
+  target: Pick<
+    PackageMetric,
+    'packageVersions' | 'productionPackageCount' | 'unpackedPackageBytes'
+  >,
+  host: HostPackageMetric,
+): boolean => {
+  const version = target.packageVersions[0]
+  return (
+    target.unpackedPackageBytes === host.unpackedPackageBytes &&
+    target.productionPackageCount === host.productionPackageCount &&
+    target.packageVersions.length === 1 &&
+    version !== undefined &&
+    version.name === host.name &&
+    version.version === host.version
+  )
+}
+
+const parseTarget = (value: unknown, index: number, host: HostPackageMetric): PackageMetric => {
   const label = `targets[${index}]`
   if (!isRecord(value)) throw new Error(`${label} must be an object`)
   const codecs =
     value.codecs === undefined ? undefined : stringArrayOf(value.codecs, `${label}.codecs`)
+  const hasUnpacked = value.unpackedPackageBytes !== undefined
+  const hasCount = value.productionPackageCount !== undefined
+  const hasVersions = value.packageVersions !== undefined
+  if (hasUnpacked !== hasCount || hasUnpacked !== hasVersions) {
+    throw new Error(
+      `${label} must omit or include unpackedPackageBytes, productionPackageCount, and packageVersions together`,
+    )
+  }
+  const unpackedPackageBytes = hasUnpacked
+    ? numberOf(value.unpackedPackageBytes, `${label}.unpackedPackageBytes`)
+    : host.unpackedPackageBytes
+  const productionPackageCount = hasCount
+    ? numberOf(value.productionPackageCount, `${label}.productionPackageCount`)
+    : host.productionPackageCount
+  const packageVersions = hasVersions
+    ? parsePackageVersions(value.packageVersions, `${label}.packageVersions`)
+    : hostPackageVersions(host)
   return {
     category: categoryOf(value.category, `${label}.category`),
     ...(codecs === undefined ? {} : { codecs }),
@@ -207,14 +250,11 @@ const parseTarget = (value: unknown, index: number): PackageMetric => {
     gzipBytes: numberOf(value.gzipBytes, `${label}.gzipBytes`),
     id: stringOf(value.id, `${label}.id`),
     implementation: implementationOf(value.implementation, `${label}.implementation`),
-    unpackedPackageBytes: numberOf(value.unpackedPackageBytes, `${label}.unpackedPackageBytes`),
+    unpackedPackageBytes,
     minifiedJsBytes: numberOf(value.minifiedJsBytes, `${label}.minifiedJsBytes`),
     name: stringOf(value.name, `${label}.name`),
-    packageVersions: parsePackageVersions(value.packageVersions, `${label}.packageVersions`),
-    productionPackageCount: numberOf(
-      value.productionPackageCount,
-      `${label}.productionPackageCount`,
-    ),
+    packageVersions,
+    productionPackageCount,
     recordedBaselineMinifiedBytes: nullableNumberOf(
       value.recordedBaselineMinifiedBytes,
       `${label}.recordedBaselineMinifiedBytes`,
@@ -279,10 +319,44 @@ const parseScientificReaderGroup = (value: unknown, index: number): ScientificRe
   }
 }
 
+const parseHostPackage = (
+  value: unknown,
+  targets: readonly unknown[],
+  schemaVersion: 2 | 3,
+): HostPackageMetric => {
+  if (!isRecord(value)) throw new Error('Package metrics package must be an object')
+  const name = stringOf(value.name, 'package.name')
+  const version = stringOf(value.version, 'package.version')
+  if (schemaVersion === 3) {
+    return {
+      name,
+      version,
+      unpackedPackageBytes: numberOf(value.unpackedPackageBytes, 'package.unpackedPackageBytes'),
+      productionPackageCount: numberOf(
+        value.productionPackageCount,
+        'package.productionPackageCount',
+      ),
+    }
+  }
+  const first = targets[0]
+  if (!isRecord(first)) throw new Error('Package metrics targets[0] must be an object')
+  return {
+    name,
+    version,
+    unpackedPackageBytes: numberOf(first.unpackedPackageBytes, 'targets[0].unpackedPackageBytes'),
+    productionPackageCount: numberOf(
+      first.productionPackageCount,
+      'targets[0].productionPackageCount',
+    ),
+  }
+}
+
 export const parsePackageMetrics = (value: unknown): PackageMetricsDocument => {
   if (!isRecord(value)) throw new Error('Package metrics must be an object')
-  if (value.schemaVersion !== 2) throw new Error('Package metrics schemaVersion must be 2')
-  if (!isRecord(value.package)) throw new Error('Package metrics package must be an object')
+  if (value.schemaVersion !== 2 && value.schemaVersion !== 3) {
+    throw new Error('Package metrics schemaVersion must be 2 or 3')
+  }
+  const schemaVersion = value.schemaVersion
   if (!Array.isArray(value.targets)) throw new Error('Package metrics targets must be an array')
   if (!Array.isArray(value.wasmAssets))
     throw new Error('Package metrics wasmAssets must be an array')
@@ -293,18 +367,16 @@ export const parsePackageMetrics = (value: unknown): PackageMetricsDocument => {
   if (!Array.isArray(value.scientificReaderGroups)) {
     throw new Error('Package metrics scientificReaderGroups must be an array')
   }
-  const targets = value.targets.map(parseTarget)
+  const host = parseHostPackage(value.package, value.targets, schemaVersion)
+  const targets = value.targets.map((target, index) => parseTarget(target, index, host))
   if (new Set(targets.map(({ id }) => id)).size !== targets.length) {
     throw new Error('Package metrics target IDs must be unique')
   }
   return {
     codecs: value.codecs.map(parseCodec),
     liveDemoReaderIds: stringArrayOf(value.liveDemoReaderIds, 'liveDemoReaderIds'),
-    package: {
-      name: stringOf(value.package.name, 'package.name'),
-      version: stringOf(value.package.version, 'package.version'),
-    },
-    schemaVersion: 2,
+    package: host,
+    schemaVersion: 3,
     scientificReaderGroups: value.scientificReaderGroups.map(parseScientificReaderGroup),
     scientificReaders: value.scientificReaders.map(parseScientificReader),
     targets,
@@ -624,11 +696,18 @@ export const measurePackageMetrics = async (
   const wasmAssets = await Promise.all(
     wasmAssetTargets.map((target) => measureWasmAsset(target, repositoryDirectory)),
   )
+  const hostTarget = targets.find((target) => target.category === 'purejsimage-entry')
+  if (hostTarget === undefined) throw new Error('Package metrics are missing a PureJsImage entry')
   return {
     codecs,
     liveDemoReaderIds,
-    package: { name: packageJson.name, version: packageJson.version },
-    schemaVersion: 2,
+    package: {
+      name: packageJson.name,
+      version: packageJson.version,
+      unpackedPackageBytes: hostTarget.unpackedPackageBytes,
+      productionPackageCount: hostTarget.productionPackageCount,
+    },
+    schemaVersion: 3,
     scientificReaderGroups: readerGroups(scientificReaders),
     scientificReaders,
     targets,
@@ -636,7 +715,38 @@ export const measurePackageMetrics = async (
   }
 }
 
-const json = (metrics: PackageMetricsDocument): string => `${JSON.stringify(metrics, null, 2)}\n`
+const compactTarget = (target: PackageMetric, host: HostPackageMetric): Record<string, unknown> => {
+  if (!sharesHostPackageFootprint(target, host)) return { ...target }
+  return {
+    category: target.category,
+    ...(target.codecs === undefined ? {} : { codecs: target.codecs }),
+    configuredCeilingMinifiedBytes: target.configuredCeilingMinifiedBytes,
+    entry: target.entry,
+    gzipBytes: target.gzipBytes,
+    id: target.id,
+    implementation: target.implementation,
+    minifiedJsBytes: target.minifiedJsBytes,
+    name: target.name,
+    recordedBaselineMinifiedBytes: target.recordedBaselineMinifiedBytes,
+    brotliBytes: target.brotliBytes,
+  }
+}
+
+const json = (metrics: PackageMetricsDocument): string =>
+  `${JSON.stringify(
+    {
+      codecs: metrics.codecs,
+      liveDemoReaderIds: metrics.liveDemoReaderIds,
+      package: metrics.package,
+      schemaVersion: 3,
+      scientificReaderGroups: metrics.scientificReaderGroups,
+      scientificReaders: metrics.scientificReaders,
+      targets: metrics.targets.map((target) => compactTarget(target, metrics.package)),
+      wasmAssets: metrics.wasmAssets,
+    },
+    null,
+    2,
+  )}\n`
 
 export const writePackageMetrics = async (
   metrics: PackageMetricsDocument,

--- a/src/scientific/readers/interchange-shared.ts
+++ b/src/scientific/readers/interchange-shared.ts
@@ -61,12 +61,121 @@ const positiveLimit = (value: number, label: string): number => {
   return value
 }
 
-const swapSamples = (input: Uint8Array, bytesPerSample: number): Uint8Array => {
-  const output = new Uint8Array(input.byteLength)
-  for (let offset = 0; offset < input.byteLength; offset += bytesPerSample) {
-    for (let byte = 0; byte < bytesPerSample; byte += 1) {
-      output[offset + byte] = input[offset + bytesPerSample - byte - 1] ?? 0
+const swapSamplesInto = (
+  input: Uint8Array,
+  output: Uint8Array,
+  outputOffset: number,
+  bytesPerSample: number,
+): void => {
+  const end = input.byteLength
+  if (bytesPerSample === 2) {
+    const inputOffset = input.byteOffset
+    const destOffset = output.byteOffset + outputOffset
+    if ((end & 1) === 0 && (inputOffset & 1) === 0 && (destOffset & 1) === 0) {
+      if ((end & 3) === 0 && (inputOffset & 3) === 0 && (destOffset & 3) === 0) {
+        const sourceView = new Uint32Array(input.buffer, inputOffset, end >> 2)
+        const destView = new Uint32Array(output.buffer, destOffset, end >> 2)
+        for (let index = 0; index < sourceView.length; index += 1) {
+          const value = sourceView[index] ?? 0
+          destView[index] = ((value & 0x00ff_00ff) << 8) | ((value >>> 8) & 0x00ff_00ff)
+        }
+        return
+      }
+      const sourceView = new Uint16Array(input.buffer, inputOffset, end >> 1)
+      const destView = new Uint16Array(output.buffer, destOffset, end >> 1)
+      for (let index = 0; index < sourceView.length; index += 1) {
+        const value = sourceView[index] ?? 0
+        destView[index] = ((value & 0xff) << 8) | (value >>> 8)
+      }
+      return
     }
+    for (let offset = 0; offset < end; offset += 2) {
+      output[outputOffset + offset] = input[offset + 1] ?? 0
+      output[outputOffset + offset + 1] = input[offset] ?? 0
+    }
+    return
+  }
+  if (bytesPerSample === 4) {
+    for (let offset = 0; offset < end; offset += 4) {
+      output[outputOffset + offset] = input[offset + 3] ?? 0
+      output[outputOffset + offset + 1] = input[offset + 2] ?? 0
+      output[outputOffset + offset + 2] = input[offset + 1] ?? 0
+      output[outputOffset + offset + 3] = input[offset] ?? 0
+    }
+    return
+  }
+  if (bytesPerSample === 8) {
+    for (let offset = 0; offset < end; offset += 8) {
+      output[outputOffset + offset] = input[offset + 7] ?? 0
+      output[outputOffset + offset + 1] = input[offset + 6] ?? 0
+      output[outputOffset + offset + 2] = input[offset + 5] ?? 0
+      output[outputOffset + offset + 3] = input[offset + 4] ?? 0
+      output[outputOffset + offset + 4] = input[offset + 3] ?? 0
+      output[outputOffset + offset + 5] = input[offset + 2] ?? 0
+      output[outputOffset + offset + 6] = input[offset + 1] ?? 0
+      output[outputOffset + offset + 7] = input[offset] ?? 0
+    }
+    return
+  }
+  for (let offset = 0; offset < end; offset += bytesPerSample) {
+    for (let byte = 0; byte < bytesPerSample; byte += 1) {
+      output[outputOffset + offset + byte] = input[offset + bytesPerSample - byte - 1] ?? 0
+    }
+  }
+}
+
+const transformSamplesInto = (
+  input: Uint8Array,
+  output: Uint8Array,
+  outputOffset: number,
+  type: RasterSampleType,
+  littleEndian: boolean,
+  transform: ContiguousValueTransform,
+): void => {
+  const sourceBytes = rasterSampleBytes(type)
+  const count = input.byteLength / sourceBytes
+  const inputView = new DataView(input.buffer, input.byteOffset, input.byteLength)
+  const outputView = new DataView(output.buffer, output.byteOffset, output.byteLength)
+  for (let index = 0; index < count; index += 1) {
+    const value = readNumeric(inputView, index * sourceBytes, type, littleEndian)
+    outputView.setFloat64(
+      outputOffset + index * 8,
+      value * transform.scale + transform.offset,
+      false,
+    )
+  }
+}
+
+const copyCanonicalInto = (
+  input: Uint8Array,
+  output: Uint8Array,
+  outputOffset: number,
+  sampleType: RasterSampleType,
+  littleEndian: boolean,
+  transform: ContiguousValueTransform | undefined,
+): void => {
+  if (transform !== undefined) {
+    transformSamplesInto(input, output, outputOffset, sampleType, littleEndian, transform)
+    return
+  }
+  const bytesPerSample = rasterSampleBytes(sampleType)
+  if (bytesPerSample === 1 || !littleEndian) {
+    output.set(input, outputOffset)
+    return
+  }
+  swapSamplesInto(input, output, outputOffset, bytesPerSample)
+}
+
+const compactStridedSamples = (
+  input: Uint8Array,
+  width: number,
+  horizontalStride: number,
+  pixelBytes: number,
+): Uint8Array => {
+  const output = new Uint8Array(width * pixelBytes)
+  for (let x = 0; x < width; x += 1) {
+    const start = x * horizontalStride * pixelBytes
+    output.set(input.subarray(start, start + pixelBytes), x * pixelBytes)
   }
   return output
 }
@@ -86,24 +195,6 @@ const readNumeric = (
   if (type === 'float32') return view.getFloat32(offset, littleEndian)
   if (type === 'float64') return view.getFloat64(offset, littleEndian)
   throw unsupportedOperation(`Numeric scaling for ${type} samples is unsupported`)
-}
-
-const transformedSamples = (
-  input: Uint8Array,
-  type: RasterSampleType,
-  littleEndian: boolean,
-  transform: ContiguousValueTransform,
-): Uint8Array => {
-  const sourceBytes = rasterSampleBytes(type)
-  const count = input.byteLength / sourceBytes
-  const output = new Uint8Array(count * 8)
-  const inputView = new DataView(input.buffer, input.byteOffset, input.byteLength)
-  const outputView = new DataView(output.buffer)
-  for (let index = 0; index < count; index += 1) {
-    const value = readNumeric(inputView, index * sourceBytes, type, littleEndian)
-    outputView.setFloat64(index * 8, value * transform.scale + transform.offset, false)
-  }
-  return output
 }
 
 class ContiguousArrayDataset implements ScientificDataset {
@@ -204,17 +295,20 @@ class ContiguousArrayDataset implements ScientificDataset {
       length,
       signal === undefined ? {} : { signal },
     )
-    if (this.#definition.transform !== undefined) {
-      return transformedSamples(
-        input,
-        this.#definition.sourceSampleType,
-        this.#definition.sourceLittleEndian,
-        this.#definition.transform,
-      )
-    }
-    const bytesPerSample = rasterSampleBytes(this.#definition.sourceSampleType)
-    if (bytesPerSample === 1 || !this.#definition.sourceLittleEndian) return Uint8Array.from(input)
-    return swapSamples(input, bytesPerSample)
+    const output = new Uint8Array(
+      this.#definition.transform === undefined
+        ? input.byteLength
+        : (input.byteLength / rasterSampleBytes(this.#definition.sourceSampleType)) * 8,
+    )
+    copyCanonicalInto(
+      input,
+      output,
+      0,
+      this.#definition.sourceSampleType,
+      this.#definition.sourceLittleEndian,
+      this.#definition.transform,
+    )
+    return output
   }
 
   async *readPlane(request: Readonly<ScientificPlaneReadRequest>): AsyncIterable<RasterBlock> {
@@ -258,51 +352,74 @@ class ContiguousArrayDataset implements ScientificDataset {
       throw limitExceeded('Interchange source row span exceeds maxRegionBytes')
     }
     const fixedOffset = this.#fixedPixelOffset(selected.fixedIndices)
+    // Packed full-width rows share one source span. Windowed rows stay per-row so a
+    // selected column does not pull unread samples from the rest of each stored row.
+    const packedRows = horizontalStride === 1 && verticalStride === selected.width
     let operations = 0
+    const countRead = (): void => {
+      operations += 1
+      if (operations > this.#definition.limits.maxReadOperations) {
+        throw limitExceeded('Interchange region exceeds maxReadOperations')
+      }
+    }
+    const readOptions = selected.signal === undefined ? {} : { signal: selected.signal }
+    const format = Object.freeze({
+      sampleType: this.descriptor.sampleType,
+      channels: this.#definition.transform === undefined ? this.descriptor.components.length : 1,
+      planar: false,
+    })
     for (let localY = 0; localY < selected.height; localY += blockRows) {
       throwIfAborted(selected.signal)
       const height = Math.min(blockRows, selected.height - localY)
       const output = new Uint8Array(outputRowBytes * height)
-      for (let row = 0; row < height; row += 1) {
-        operations += 1
-        if (operations > this.#definition.limits.maxReadOperations) {
-          throw limitExceeded('Interchange region exceeds maxReadOperations')
-        }
-        const pixel =
-          fixedOffset + (selected.y + localY + row) * verticalStride + selected.x * horizontalStride
+      if (packedRows) {
+        countRead()
+        const pixel = fixedOffset + (selected.y + localY) * verticalStride + selected.x
         const span = await readExactly(
           this.#definition.source,
           this.#definition.dataOffset + pixel * this.#sourcePixelBytes,
-          sourceRowBytes,
-          selected.signal === undefined ? {} : { signal: selected.signal },
+          checkedProduct([height, sourceRowBytes], 'Interchange packed block bytes'),
+          readOptions,
         )
-        const compact =
-          horizontalStride === 1
-            ? span
-            : (() => {
-                const bytes = new Uint8Array(selected.width * this.#sourcePixelBytes)
-                for (let x = 0; x < selected.width; x += 1) {
-                  const start = x * horizontalStride * this.#sourcePixelBytes
-                  bytes.set(
-                    span.subarray(start, start + this.#sourcePixelBytes),
-                    x * this.#sourcePixelBytes,
-                  )
-                }
-                return bytes
-              })()
-        const canonical =
-          this.#definition.transform === undefined
-            ? rasterSampleBytes(this.#definition.sourceSampleType) === 1 ||
-              !this.#definition.sourceLittleEndian
-              ? Uint8Array.from(compact)
-              : swapSamples(compact, rasterSampleBytes(this.#definition.sourceSampleType))
-            : transformedSamples(
-                compact,
-                this.#definition.sourceSampleType,
-                this.#definition.sourceLittleEndian,
-                this.#definition.transform,
-              )
-        output.set(canonical, row * outputRowBytes)
+        copyCanonicalInto(
+          span,
+          output,
+          0,
+          this.#definition.sourceSampleType,
+          this.#definition.sourceLittleEndian,
+          this.#definition.transform,
+        )
+      } else {
+        for (let row = 0; row < height; row += 1) {
+          countRead()
+          const pixel =
+            fixedOffset +
+            (selected.y + localY + row) * verticalStride +
+            selected.x * horizontalStride
+          const span = await readExactly(
+            this.#definition.source,
+            this.#definition.dataOffset + pixel * this.#sourcePixelBytes,
+            sourceRowBytes,
+            readOptions,
+          )
+          const compact =
+            horizontalStride === 1
+              ? span
+              : compactStridedSamples(
+                  span,
+                  selected.width,
+                  horizontalStride,
+                  this.#sourcePixelBytes,
+                )
+          copyCanonicalInto(
+            compact,
+            output,
+            row * outputRowBytes,
+            this.#definition.sourceSampleType,
+            this.#definition.sourceLittleEndian,
+            this.#definition.transform,
+          )
+        }
       }
       yield {
         x: selected.x,
@@ -310,12 +427,7 @@ class ContiguousArrayDataset implements ScientificDataset {
         width: selected.width,
         height,
         stride: outputRowBytes,
-        format: Object.freeze({
-          sampleType: this.descriptor.sampleType,
-          channels:
-            this.#definition.transform === undefined ? this.descriptor.components.length : 1,
-          planar: false,
-        }),
+        format,
         data: output,
       }
     }

--- a/tests/package-metrics.test.ts
+++ b/tests/package-metrics.test.ts
@@ -101,6 +101,82 @@ describe('generated package metrics contract', () => {
     ).toBe(true)
   })
 
+  it('reads a v2 metrics document even when a competitor target is listed first', () => {
+    const parsed = parsePackageMetrics({
+      schemaVersion: 2,
+      package: { name: 'purejsimage', version: '0.10.0' },
+      liveDemoReaderIds: [],
+      codecs: [],
+      scientificReaders: [],
+      scientificReaderGroups: [],
+      wasmAssets: [],
+      targets: [
+        {
+          category: 'competitor',
+          configuredCeilingMinifiedBytes: null,
+          entry: { packageExports: ['jimp'] },
+          gzipBytes: 1,
+          id: 'jimp',
+          implementation: 'pure-javascript',
+          unpackedPackageBytes: 99_000,
+          minifiedJsBytes: 10,
+          name: 'Jimp',
+          packageVersions: [{ name: 'jimp', version: '1.0.0' }],
+          productionPackageCount: 70,
+          recordedBaselineMinifiedBytes: null,
+          brotliBytes: 1,
+        },
+        {
+          category: 'purejsimage-entry',
+          configuredCeilingMinifiedBytes: null,
+          entry: { packageExports: ['purejsimage'] },
+          gzipBytes: 2,
+          id: 'core',
+          implementation: 'package-core',
+          unpackedPackageBytes: 4_000,
+          minifiedJsBytes: 20,
+          name: 'Core API',
+          packageVersions: [{ name: 'purejsimage', version: '0.10.0' }],
+          productionPackageCount: 1,
+          recordedBaselineMinifiedBytes: null,
+          brotliBytes: 2,
+        },
+      ],
+    })
+    expect(parsed.package.unpackedPackageBytes).toBe(4_000)
+    expect(parsed.package.productionPackageCount).toBe(1)
+    expect(parsed.targets[0]?.unpackedPackageBytes).toBe(99_000)
+    expect(parsed.targets[1]?.unpackedPackageBytes).toBe(4_000)
+    expect(() =>
+      parsePackageMetrics({
+        schemaVersion: 2,
+        package: { name: 'purejsimage', version: '0.10.0' },
+        liveDemoReaderIds: [],
+        codecs: [],
+        scientificReaders: [],
+        scientificReaderGroups: [],
+        wasmAssets: [],
+        targets: [
+          {
+            category: 'purejsimage-entry',
+            configuredCeilingMinifiedBytes: null,
+            entry: { packageExports: ['purejsimage'] },
+            gzipBytes: 2,
+            id: 'core',
+            implementation: 'package-core',
+            unpackedPackageBytes: 4_000,
+            minifiedJsBytes: 20,
+            name: 'Core API',
+            packageVersions: [{ name: 'purejsimage', version: '9.9.9' }],
+            productionPackageCount: 1,
+            recordedBaselineMinifiedBytes: null,
+            brotliBytes: 2,
+          },
+        ],
+      }),
+    ).toThrow(/packageVersions must match package.name and package.version/u)
+  })
+
   it('stores the host package footprint once instead of copying it onto every entry', () => {
     const serialized = JSON.parse(serializePackageMetrics(metrics)) as {
       readonly package: { readonly unpackedPackageBytes: number }

--- a/tests/package-metrics.test.ts
+++ b/tests/package-metrics.test.ts
@@ -86,6 +86,9 @@ describe('generated package metrics contract', () => {
     const serialized = serializePackageMetrics(metrics)
     expect(serialized).not.toMatch(/generatedAt|timestamp|\/home\/|\/media\/|[A-Za-z]:\\\\/u)
     expect(metrics.package.name).toBe('purejsimage')
+    expect(metrics.package.unpackedPackageBytes).toBeGreaterThan(0)
+    expect(metrics.package.productionPackageCount).toBe(1)
+    expect(metrics.schemaVersion).toBe(3)
     expect(metrics.targets).toHaveLength(pureTargets.length + competitorTargets.length)
     expect(metrics.targets.every(({ packageVersions }) => packageVersions.length > 0)).toBe(true)
     expect(metrics.targets.every(({ unpackedPackageBytes }) => unpackedPackageBytes > 0)).toBe(true)
@@ -94,6 +97,27 @@ describe('generated package metrics contract', () => {
     expect(
       metrics.wasmAssets.every(
         ({ rawBytes, gzipBytes, brotliBytes }) => rawBytes > 0 && gzipBytes > 0 && brotliBytes > 0,
+      ),
+    ).toBe(true)
+  })
+
+  it('stores the host package footprint once instead of copying it onto every entry', () => {
+    const serialized = JSON.parse(serializePackageMetrics(metrics)) as {
+      readonly package: { readonly unpackedPackageBytes: number }
+      readonly targets: readonly Record<string, unknown>[]
+    }
+    expect(serialized.package.unpackedPackageBytes).toBe(metrics.package.unpackedPackageBytes)
+    const hostTargets = serialized.targets.filter(
+      (target) => target.unpackedPackageBytes === undefined && target.packageVersions === undefined,
+    )
+    const foreignTargets = serialized.targets.filter(
+      (target) => target.unpackedPackageBytes !== undefined,
+    )
+    expect(hostTargets.length).toBeGreaterThan(50)
+    expect(foreignTargets.length).toBeGreaterThan(0)
+    expect(
+      foreignTargets.every(
+        (target) => target.unpackedPackageBytes !== serialized.package.unpackedPackageBytes,
       ),
     ).toBe(true)
   })

--- a/tests/scientific-interchange-formats.test.ts
+++ b/tests/scientific-interchange-formats.test.ts
@@ -241,6 +241,57 @@ describe('Milestone H interchange and detector readers', () => {
     await expect(planeValues(f)).resolves.toEqual([1, 2, 3, 4, 5, 6])
   })
 
+  it('coalesces sequential packed NPY rows into one source read per output block', async () => {
+    const values = Array.from({ length: 32 }, (_value, index) => index + 1)
+    const bytes = npy([8, 4], values)
+    const dataOffset = 10 + new DataView(bytes.buffer).getUint16(8, true)
+    const source = new TrackingSource(bytes)
+    const reader = createNpyReader({ limits: { rowsPerBlock: 4 } })
+    const document = await reader.open({
+      primary: { id: 'primary', name: 'packed.npy', source },
+    })
+    const headerReads = source.reads.length
+    const dataset = await document.openDataset('array')
+    await expect(planeValues(dataset)).resolves.toEqual(values)
+    expect(source.reads.slice(headerReads)).toEqual([
+      { offset: dataOffset, length: 32 },
+      { offset: dataOffset + 32, length: 32 },
+    ])
+  })
+
+  it('keeps windowed interchange reads on selected row spans', async () => {
+    const values = Array.from({ length: 32 }, (_value, index) => index + 1)
+    const bytes = npy([4, 8], values)
+    const dataOffset = 10 + new DataView(bytes.buffer).getUint16(8, true)
+    const source = new TrackingSource(bytes)
+    const document = await npyReader.open({
+      primary: { id: 'primary', name: 'window.npy', source },
+    })
+    source.reads.splice(0)
+    const dataset = await document.openDataset('array')
+    const selected: number[] = []
+    for await (const block of dataset.readPlane({
+      displayAxes: ['axis1', 'axis0'],
+      fixedIndices: [],
+      x: 2,
+      y: 1,
+      width: 3,
+      height: 2,
+    })) {
+      const view = new DataView(block.data.buffer, block.data.byteOffset, block.data.byteLength)
+      for (let y = 0; y < block.height; y += 1) {
+        for (let x = 0; x < block.width; x += 1) {
+          selected.push(readRasterSample(block.data, view, y * block.stride + x * 2, 'uint16'))
+        }
+      }
+    }
+    expect(selected).toEqual([11, 12, 13, 19, 20, 21])
+    expect(source.reads).toEqual([
+      { offset: dataOffset + 20, length: 6 },
+      { offset: dataOffset + 36, length: 6 },
+    ])
+  })
+
   it('reads paired RPL/RAW vector records with sidecar calibration', async () => {
     const header = text(`key\tvalue
 width\t2
@@ -695,7 +746,7 @@ data file: payload.raw
 
   it('enforces operation, element, compression, cancellation, and truncation limits', async () => {
     const operationLimited = createNpyReader({
-      limits: { maxReadOperations: 1, rowsPerBlock: 2 },
+      limits: { maxReadOperations: 1, rowsPerBlock: 1 },
     })
     const dataset = await openDataset(
       operationLimited,

--- a/tests/scientific-interchange-formats.test.ts
+++ b/tests/scientific-interchange-formats.test.ts
@@ -193,6 +193,38 @@ const modifiedNifti1 = (modify: (view: DataView) => void): Uint8Array<ArrayBuffe
   return bytes
 }
 
+const scaledNifti1Plane = (
+  width: number,
+  height: number,
+  values: readonly number[],
+): Uint8Array<ArrayBuffer> => {
+  if (values.length !== width * height) {
+    throw new Error('NIfTI fixture values must match width × height')
+  }
+  const dataOffset = 352
+  const output = new Uint8Array(dataOffset + values.length * 2)
+  const view = new DataView(output.buffer)
+  view.setInt32(0, 348, true)
+  view.setInt16(40, 2, true)
+  view.setInt16(42, width, true)
+  view.setInt16(44, height, true)
+  view.setInt16(46, 1, true)
+  view.setInt16(70, 4, true)
+  view.setInt16(72, 16, true)
+  view.setFloat32(76, 1, true)
+  view.setFloat32(80, 1, true)
+  view.setFloat32(84, 1, true)
+  view.setFloat32(108, dataOffset, true)
+  view.setFloat32(112, 2, true)
+  view.setFloat32(116, 1, true)
+  output[123] = 2
+  output.set(text('n+1\0'), 344)
+  for (const [index, value] of values.entries()) {
+    view.setInt16(dataOffset + index * 2, value, true)
+  }
+  return output
+}
+
 const blockfile = (): Uint8Array<ArrayBuffer> => {
   const output = new Uint8Array(284)
   const view = new DataView(output.buffer)
@@ -431,6 +463,19 @@ ElementDataFile = image.raw
     await expect(
       planeValues(await openDataset(niftiReader, context('volume-v2.nii', nifti2()))),
     ).resolves.toEqual([1, 2, 3, 4])
+  })
+
+  it('applies NIfTI scaling across a coalesced multi-row plane', async () => {
+    const bytes = scaledNifti1Plane(2, 3, [1, 2, 3, 4, 5, 6])
+    const source = new TrackingSource(bytes)
+    const document = await niftiReader.open({
+      primary: { id: 'primary', name: 'scaled.nii', source },
+    })
+    source.reads.splice(0)
+    const dataset = await document.openDataset('volume')
+    await expect(planeValues(dataset)).resolves.toEqual([3, 5, 7, 9, 11, 13])
+    expect(dataset.descriptor.sampleType).toBe('float64')
+    expect(source.reads).toEqual([{ offset: 352, length: 12 }])
   })
 
   it('ignores scl_inter when scl_slope is zero in NIfTI-1 and NIfTI-2', async () => {


### PR DESCRIPTION
NPY, NIfTI, and NRRD full-plane reads issued one source request per row. Packed rows now share one read per output block, write canonical samples directly into that block, and use a faster 16-bit endian swap. Windowed regions stay per-row so selected columns do not over-fetch.

Store the host npm package footprint once in package-metrics instead of copying the same unpacked size onto every PureJsImage target.