### PR TITLE
perf(png): speed up adaptive filter scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,10 @@ PureJsImage 0.13.0 is a zero-runtime-dependency strict TypeScript image-processi
 | Current measured surface | Minified JS | gzip | Brotli |
 | --- | ---: | ---: | ---: |
 | Core API | 60.0 KiB | 19.0 KiB | 16.8 KiB |
-| Common web codecs | 607.9 KiB | 224.5 KiB | 188.1 KiB |
-| All stable codecs | 870.6 KiB | 306.3 KiB | 252.5 KiB |
+| Common web codecs | 607.6 KiB | 224.4 KiB | 188.0 KiB |
+| All stable codecs | 870.4 KiB | 306.2 KiB | 252.4 KiB |
 | Scientific platform | 157.0 KiB | 45.6 KiB | 38.9 KiB |
-| All scientific readers | 1211.6 KiB | 350.5 KiB | 279.8 KiB |
+| All scientific readers | 1211.3 KiB | 350.4 KiB | 279.6 KiB |
 
 The extracted npm package is 5.7 MiB with 1 production package. This is unpacked size, not the compressed npm tarball.
 <!-- documentation:summary:end -->
@@ -295,10 +295,10 @@ Generated for purejsimage 0.13.0. The README keeps only the major entry points; 
 | Surface | Import | Minified JS | gzip | Brotli |
 | --- | --- | ---: | ---: | ---: |
 | Core API | `purejsimage` | 60.0 KiB | 19.0 KiB | 16.8 KiB |
-| Core + common web codecs | `purejsimage/codecs/web` | 607.9 KiB | 224.5 KiB | 188.1 KiB |
-| Core + all stable codecs | `purejsimage/codecs/all` | 870.6 KiB | 306.3 KiB | 252.5 KiB |
+| Core + common web codecs | `purejsimage/codecs/web` | 607.6 KiB | 224.4 KiB | 188.0 KiB |
+| Core + all stable codecs | `purejsimage/codecs/all` | 870.4 KiB | 306.2 KiB | 252.4 KiB |
 | Core + scientific platform | `purejsimage/scientific` | 157.0 KiB | 45.6 KiB | 38.9 KiB |
-| Scientific readers: all | `purejsimage/scientific/readers/all` | 1211.6 KiB | 350.5 KiB | 279.8 KiB |
+| Scientific readers: all | `purejsimage/scientific/readers/all` | 1211.3 KiB | 350.4 KiB | 279.6 KiB |
 
 The extracted npm package is 5.7 MiB and has 1 production package. The six optional JPEG and PNG accelerator assets total 157.4 KiB raw WASM and are loaded only through explicit accelerator imports.
 

--- a/benchmark/generated/package-metrics.json
+++ b/benchmark/generated/package-metrics.json
@@ -176,7 +176,7 @@
   "package": {
     "name": "purejsimage",
     "version": "0.13.0",
-    "unpackedPackageBytes": 5927481,
+    "unpackedPackageBytes": 5926167,
     "productionPackageCount": 1
   },
   "schemaVersion": 3,
@@ -793,13 +793,13 @@
         "packageExports": ["purejsimage/scientific/readers/png"],
         "sourceEntries": ["./src/scientific/readers/png.ts"]
       },
-      "gzipBytes": 24231,
+      "gzipBytes": 24122,
       "id": "scientific-reader-png",
       "implementation": "package-core",
-      "minifiedJsBytes": 72353,
+      "minifiedJsBytes": 72059,
       "name": "Scientific reader: PNG",
       "recordedBaselineMinifiedBytes": 67385,
-      "brotliBytes": 21108
+      "brotliBytes": 21025
     },
     {
       "category": "purejsimage-entry",
@@ -1153,13 +1153,13 @@
         "packageExports": ["purejsimage/scientific/readers/all"],
         "sourceEntries": ["./src/scientific/readers/all.ts"]
       },
-      "gzipBytes": 358962,
+      "gzipBytes": 358826,
       "id": "scientific-readers-all",
       "implementation": "package-core",
-      "minifiedJsBytes": 1240645,
+      "minifiedJsBytes": 1240347,
       "name": "Scientific readers: all",
       "recordedBaselineMinifiedBytes": 844813,
-      "brotliBytes": 286482
+      "brotliBytes": 286316
     },
     {
       "category": "purejsimage-entry",
@@ -1183,13 +1183,13 @@
         "packageExports": ["purejsimage/codecs/png"],
         "sourceEntries": ["./src/index.ts", "./src/codec-entries/png.ts"]
       },
-      "gzipBytes": 31863,
+      "gzipBytes": 31746,
       "id": "codec-png",
       "implementation": "pure-javascript",
-      "minifiedJsBytes": 96850,
+      "minifiedJsBytes": 96555,
       "name": "Core + PNG",
       "recordedBaselineMinifiedBytes": null,
-      "brotliBytes": 27559
+      "brotliBytes": 27410
     },
     {
       "category": "purejsimage-entry",
@@ -1258,13 +1258,13 @@
         "packageExports": ["purejsimage/codecs/ico"],
         "sourceEntries": ["./src/index.ts", "./src/codec-entries/ico.ts"]
       },
-      "gzipBytes": 34961,
+      "gzipBytes": 34859,
       "id": "codec-ico",
       "implementation": "pure-javascript",
-      "minifiedJsBytes": 106224,
+      "minifiedJsBytes": 105926,
       "name": "Core + ICO",
       "recordedBaselineMinifiedBytes": null,
-      "brotliBytes": 30203
+      "brotliBytes": 30093
     },
     {
       "category": "purejsimage-entry",
@@ -1394,13 +1394,13 @@
         "packageExports": ["purejsimage/codecs/web"],
         "sourceEntries": ["./src/index.ts", "./src/codec-entries/web.ts"]
       },
-      "gzipBytes": 229888,
+      "gzipBytes": 229781,
       "id": "codecs-web",
       "implementation": "pure-javascript",
-      "minifiedJsBytes": 622446,
+      "minifiedJsBytes": 622148,
       "name": "Core + common web codecs",
       "recordedBaselineMinifiedBytes": null,
-      "brotliBytes": 192567
+      "brotliBytes": 192469
     },
     {
       "category": "purejsimage-entry",
@@ -1425,13 +1425,13 @@
         "packageExports": ["purejsimage/codecs/all"],
         "sourceEntries": ["./src/index.ts", "./src/codec-entries/all.ts"]
       },
-      "gzipBytes": 313647,
+      "gzipBytes": 313543,
       "id": "codecs-all",
       "implementation": "pure-javascript",
-      "minifiedJsBytes": 891539,
+      "minifiedJsBytes": 891241,
       "name": "Core + all stable codecs",
       "recordedBaselineMinifiedBytes": null,
-      "brotliBytes": 258563
+      "brotliBytes": 258491
     },
     {
       "category": "competitor",
@@ -1440,13 +1440,13 @@
       "entry": {
         "packageExports": ["purejsimage"]
       },
-      "gzipBytes": 54123,
+      "gzipBytes": 54024,
       "id": "purejsimage-matched",
       "implementation": "pure-javascript",
-      "minifiedJsBytes": 168511,
+      "minifiedJsBytes": 168213,
       "name": "PureJsImage (matched)",
       "recordedBaselineMinifiedBytes": null,
-      "brotliBytes": 44983
+      "brotliBytes": 44896
     },
     {
       "category": "competitor",
@@ -1470,13 +1470,13 @@
       "entry": {
         "packageExports": ["purejsimage/codecs/all"]
       },
-      "gzipBytes": 313647,
+      "gzipBytes": 313543,
       "id": "purejsimage-all",
       "implementation": "pure-javascript",
-      "minifiedJsBytes": 891539,
+      "minifiedJsBytes": 891241,
       "name": "PureJsImage (all stable codecs)",
       "recordedBaselineMinifiedBytes": null,
-      "brotliBytes": 258563
+      "brotliBytes": 258491
     },
     {
       "category": "competitor",

--- a/benchmark/optimization-log.md
+++ b/benchmark/optimization-log.md
@@ -14,7 +14,14 @@ repeat a dead end without new evidence.
 - Retained `PNG-001`: indexed CRC-32. 15-trial 562 → 527 ms (−6.29%).
 - Retained `PNG-003`: memcpy 8-bit RGBA `convertRow`. 15-trial 537 → 416 ms
   (−22.52% vs original HEAD), 14/15 pairs faster, paired MAD 1.04%.
-- Versus Sharp (~263 ms) the primary is now ~416 ms (~1.6×).
+- Retained `PNG-015/016`: generalize adaptive-filter prefix/body scoring to remove RGBA boundary
+  branches and the redundant RGB-only kernel. 15-trial 437 → 433 ms (−0.82%), paired median
+  −1.03%, 12/15 pairs faster, RSS −0.62%.
+- Retained `PNG-017/018`: use a 256-entry filtered-magnitude lookup. The cumulative 15-trial
+  stack is 438 → 432 ms (−1.35%), paired median −1.06%, 13/15 pairs faster, RSS −0.05%.
+- `PNG-008` reached −6.07% but was superseded because its fully unrolled kernel exceeded the core
+  bundle ceiling.
+- Versus Sharp (~263 ms), the final stack's latest paired candidate median is ~432 ms (~1.6×).
 - Neighbor `stress-100mp-downscale`: 2653 → 1391 ms (−47.58%), RSS −1.55%, exact
   signatures. Artifact `.tmp/hillclimb/2026-08-19T13-08-00-007Z/`.
 - Neighbor `png-alpha-resize`: 79.89 → 72.99 ms (−8.63%), RSS −0.07%.
@@ -22,7 +29,7 @@ repeat a dead end without new evidence.
 - Neighbor `jpeg-to-png`: 483.46 → 479.43 ms (−0.83%), RSS −0.98%. CRC-only
   effect. Artifact `.tmp/hillclimb/2026-08-19T13-10-00-061Z/`.
 - Imazen PNG: 176 images, 162 pass / 14 rejected-safely / 0 failures.
-  Artifact `.tmp/imazen-png-001/`.
+  Artifact `.tmp/imazen-png-final/`.
 
 - Reverted `PNG-002` RGBA8 unfilter; incremental vs PNG-001 was noise.
 - Progressive `jpeg-progressive-resize-1200` JPEG-039/040/041 did not retain.
@@ -137,6 +144,26 @@ repeat a dead end without new evidence.
 | PNG-001 | 2026-08-19 12:58 | Indexed `updateCrc32` loop instead of `for-of` over `Uint8Array`. | 562.10 → 526.74 | **-6.29%** | +3.53% | material | Retained. 15/15-trial; 12/15 pairs faster; paired median −7.06%; exact outputBytes 43059. 7-trial was −1.48% / 5/7. Artifacts `.tmp/hillclimb/2026-08-19T12-56-59-749Z/` and `.tmp/hillclimb/2026-08-19T12-57-56-662Z/`. |
 | PNG-002 | 2026-08-19 13:02 | Specialize RGBA8 unfilter and inline Paeth without `Math.abs`. | 555.91 → 533.02 | -4.12% vs HEAD | -0.24% | inconclusive | Reverted. Incremental vs PNG-001 (~527 ms) was noise; 15-trial base CV 18.7% from a 990 ms outlier. Artifact `.tmp/hillclimb/2026-08-19T13-01-44-856Z/`. |
 | PNG-003 | 2026-08-19 13:05 | `convertRow` memcpy for 8-bit RGBA without tRNS. | 536.57 → 415.76 | **-22.52%** | +0.22% | material | Retained on PNG-001. 14/15 pairs faster; paired median −22.52%; exact outputBytes. 7-trial incomparable (candidate CV 11.9%) then 15-trial accepted. Artifacts `.tmp/hillclimb/2026-08-19T13-04-25-604Z/` and `.tmp/hillclimb/2026-08-19T13-05-21-086Z/`. |
+| PNG-004 | 2026-08-20 01:25 | No-change control at `1621ad3` after re-profiling the committed PNG-001/003 stack. | 450.37 → 468.16 | +3.95% | +0.10% | inconclusive | Control; no source change. Base CV 17.12%, candidate CV 7.86%, paired median +0.45% with 3/7 candidate-faster pairs. Correctness and outputBytes matched. Artifact `.tmp/hillclimb/2026-08-20T01-25-01-614Z/`. |
+| PNG-005 | 2026-08-20 01:27 | Express Paeth distances directly as `up-upperLeft`, `left-upperLeft`, and `left+up-2*upperLeft` to remove the shared prediction temporary. | 448.16 → 447.91 | -0.06% | +0.18% | neutral | Reverted. Paired median −0.13%, 4/7 pairs faster; base/candidate CV 0.81%/0.83%, exact outputBytes. Artifact `.tmp/hillclimb/2026-08-20T01-26-43-137Z/`. |
+| PNG-006 | 2026-08-20 01:29 | Unroll filter-type 2 reconstruction four bytes at a time when `filterBytesPerPixel === 4`. | 443.40 → 452.62 | +2.08% | +0.42% | inconclusive | Retained only for confirmation. Host outliers drove base/candidate CV to 33.34%/18.33%; paired median +0.87%, 3/7 pairs faster, exact outputBytes. Artifact `.tmp/hillclimb/2026-08-20T01-28-19-127Z/`. |
+| PNG-007 | 2026-08-20 01:31 | Confirm PNG-006 with 15 paired trials. | 438.10 → 439.10 | +0.23% | +0.03% | neutral | Reverted. Two base outliers kept base CV at 14.13%, but the robust paired median was only −0.18% with 9/15 pairs faster, below the promising range; candidate CV 2.66%, exact outputBytes. Artifact `.tmp/hillclimb/2026-08-20T01-29-34-597Z/`. |
+| PNG-008 | 2026-08-20 01:33 | Unroll exact factor-4 RGBA box-shrink accumulation in `src/resize.ts`, preserving premultiplied sums and final rounding. | 437.66 → 411.08 | **-6.07%** | -0.15% | material | Superseded after the final size gate: the fully unrolled kernel exceeded the 61,440-byte core API ceiling by 360 bytes. Paired median −5.68%, 7/7 pairs faster; base/candidate CV 1.29%/1.55%, exact outputBytes. Artifact `.tmp/hillclimb/2026-08-20T01-32-47-404Z/`. |
+| PNG-009 | 2026-08-20 01:36 | Confirm the cumulative PNG-008 stack with 15 paired trials. | 444.86 → 417.51 | **-6.15%** | +0.11% | inconclusive | Retained based on PNG-008. The direction confirmed in 14/15 pairs with paired median −5.56% and exact outputBytes, but one 681 ms candidate outlier raised candidate CV to 15.14%, so the runner correctly marked this confirmation incomparable. Artifact `.tmp/hillclimb/2026-08-20T01-34-10-493Z/`. |
+| PNG-010 | 2026-08-20 01:37 | Validate PNG-008 on neighboring `png-alpha-resize`, whose 1200→800 ratio does not select the factor-4 path. | 76.76 → 77.08 | +0.42% | +0.01% | neutral | Validation only; retained stack unchanged. Paired median +0.48%, 2/7 pairs faster; base/candidate CV 1.19%/1.30%, exact outputBytes. Artifact `.tmp/hillclimb/2026-08-20T01-36-15-652Z/`. |
+| PNG-011 | 2026-08-20 01:39 | Validate PNG-008 on neighboring `stress-100mp-downscale`, which selects the adjacent factor-8 path. | 1263.33 → 1317.80 | +4.31% | +0.61% | neutral | Retained only pending a 15-pair regression guard. Paired median +2.65%, 2/7 pairs faster; base/candidate CV 5.53%/2.86%, exact outputBytes. Artifact `.tmp/hillclimb/2026-08-20T01-37-08-391Z/`. |
+| PNG-012 | 2026-08-20 01:42 | Confirm PNG-011's factor-8 neighboring regression guard with 15 paired trials. | 1277.37 → 1273.07 | -0.34% | -0.01% | neutral | Validation passed; retained PNG-008. Paired median −0.93%, 9/15 pairs faster; base/candidate CV 3.21%/1.71%, exact outputBytes. Artifact `.tmp/hillclimb/2026-08-20T01-39-09-085Z/`. |
+| PNG-013 | 2026-08-20 01:51 | Replace per-pixel `sourceX * 4` in RGBA box shrink with one streaming byte offset, keeping the generic partial-group path and bundle ceiling. | 444.92 → 440.70 | -0.95% | -0.17% | promising | Retained conditionally for 15-pair confirmation. Paired median −0.95%, 5/7 pairs faster; base/candidate CV 2.59%/1.57%, exact outputBytes. Artifact `.tmp/hillclimb/2026-08-20T01-49-48-784Z/`. |
+| PNG-014 | 2026-08-20 01:53 | Confirm PNG-013 with 15 paired trials. | 439.25 → 439.43 | +0.04% | +0.04% | neutral | Reverted. Paired median −0.62%, only 8/15 pairs faster; base/candidate CV 3.54%/8.48%, exact outputBytes. Artifact `.tmp/hillclimb/2026-08-20T01-51-15-965Z/`. |
+| PNG-015 | 2026-08-20 01:56 | Generalize the adaptive-filter prefix/body split so RGBA scoring avoids per-byte `index >= bytesPerPixel` branches, then remove the redundant RGB-only kernel. | 434.45 → 429.81 | -1.07% | -0.08% | promising | Retained conditionally for 15-pair confirmation. Paired median −0.83%, 6/7 pairs faster; base/candidate CV 0.61%/1.44%, exact outputBytes. Artifact `.tmp/hillclimb/2026-08-20T01-54-42-913Z/`. |
+| PNG-016 | 2026-08-20 01:58 | Confirm PNG-015 with 15 paired trials. | 436.79 → 433.22 | -0.82% | -0.62% | promising | Retained. Paired median −1.03%, 12/15 pairs faster; base/candidate CV 2.12%/0.92%, exact outputBytes. Artifact `.tmp/hillclimb/2026-08-20T01-55-52-331Z/`. |
+| PNG-017 | 2026-08-20 02:00 | Add a 256-entry filtered-residual magnitude lookup on the retained PNG-015/016 stack. | 438.14 → 431.89 | -1.43% | -0.69% | promising | Retained conditionally for 15-pair cumulative confirmation. Paired median −1.91%, 7/7 pairs faster; base/candidate CV 5.45%/0.37%, exact outputBytes. Artifact `.tmp/hillclimb/2026-08-20T01-58-38-026Z/`. |
+| PNG-018 | 2026-08-20 02:02 | Confirm the cumulative PNG-015–017 stack with 15 paired trials. | 438.16 → 432.26 | -1.35% | -0.05% | promising | Retained. Paired median −1.06%, 13/15 pairs faster; base/candidate CV 1.58%/9.02% (one 592 ms candidate outlier), exact outputBytes. Artifact `.tmp/hillclimb/2026-08-20T01-59-54-761Z/`. |
+| PNG-019 | 2026-08-20 02:04 | Unroll `updateCrc32` four bytes at a time on the retained PNG-015–018 stack. | 443.44 → 439.97 | -0.78% | +0.37% | neutral | Reverted. The cumulative result weakened versus PNG-018 despite a paired median of −0.78% and 6/7 faster pairs; exact outputBytes, base/candidate CV 0.75%/0.83%. Artifact `.tmp/hillclimb/2026-08-20T02-02-34-377Z/`. |
+| PNG-020 | 2026-08-20 02:05 | Replace exact nonnegative `/ 2` floors in Average-filter scoring with unsigned shifts on the retained PNG-015–018 stack. | 442.40 → 437.56 | -1.09% | +0.37% | neutral | Reverted. All 7 pairs favored the candidate, but paired median −1.03% was indistinguishable from retained PNG-018 and the cumulative median weakened; exact outputBytes, base/candidate CV 0.95%/0.58%. Artifact `.tmp/hillclimb/2026-08-20T02-04-08-261Z/`. |
+| PNG-021 | 2026-08-20 02:07 | Validate the final PNG-015–018 stack on neighboring `png-alpha-resize`. | 77.34 → 77.39 | +0.07% | -0.04% | neutral | Validation passed; retained stack unchanged. Paired median −0.66%, 4/7 pairs faster; base/candidate CV 1.04%/0.90%, exact outputBytes. Artifact `.tmp/hillclimb/2026-08-20T02-05-50-552Z/`. |
+| PNG-022 | 2026-08-20 02:08 | Validate the final PNG-015–018 stack on neighboring `jpeg-to-png`. | 411.30 → 416.72 | +1.32% | +0.16% | neutral | Retained only pending a 15-pair regression guard. Paired median +1.66%, 2/7 pairs faster; base/candidate CV 1.31%/1.28%, exact outputBytes. Artifact `.tmp/hillclimb/2026-08-20T02-07-09-100Z/`. |
+| PNG-023 | 2026-08-20 02:10 | Confirm PNG-022's `jpeg-to-png` neighboring regression guard with 15 paired trials. | 414.93 → 417.84 | +0.70% | -0.44% | neutral | Validation passed; retained final stack. Paired median +0.51%, 6/15 pairs faster; base/candidate CV 2.09%/1.62%, exact outputBytes, well below the 5% regression guard. Artifact `.tmp/hillclimb/2026-08-20T02-08-20-360Z/`. |
 
 
 

--- a/docs-astro/src/data/documentation-data.json
+++ b/docs-astro/src/data/documentation-data.json
@@ -96,19 +96,19 @@
   },
   "sizes": {
     "allReaders": {
-      "brotliBytes": 286482,
-      "gzipBytes": 358962,
-      "minifiedBytes": 1240645
+      "brotliBytes": 286316,
+      "gzipBytes": 358826,
+      "minifiedBytes": 1240347
     },
     "allStableCodecs": {
-      "brotliBytes": 258563,
-      "gzipBytes": 313647,
-      "minifiedBytes": 891539
+      "brotliBytes": 258491,
+      "gzipBytes": 313543,
+      "minifiedBytes": 891241
     },
     "commonWebCodecs": {
-      "brotliBytes": 192567,
-      "gzipBytes": 229888,
-      "minifiedBytes": 622446
+      "brotliBytes": 192469,
+      "gzipBytes": 229781,
+      "minifiedBytes": 622148
     },
     "core": {
       "brotliBytes": 17195,
@@ -116,7 +116,7 @@
       "minifiedBytes": 61435
     },
     "installedPackage": {
-      "bytes": 5927481,
+      "bytes": 5926167,
       "productionPackageCount": 1
     },
     "packageVersion": "0.13.0",

--- a/docs-astro/src/data/package-metrics.json
+++ b/docs-astro/src/data/package-metrics.json
@@ -176,7 +176,7 @@
   "package": {
     "name": "purejsimage",
     "version": "0.13.0",
-    "unpackedPackageBytes": 5927481,
+    "unpackedPackageBytes": 5926167,
     "productionPackageCount": 1
   },
   "schemaVersion": 3,
@@ -793,13 +793,13 @@
         "packageExports": ["purejsimage/scientific/readers/png"],
         "sourceEntries": ["./src/scientific/readers/png.ts"]
       },
-      "gzipBytes": 24231,
+      "gzipBytes": 24122,
       "id": "scientific-reader-png",
       "implementation": "package-core",
-      "minifiedJsBytes": 72353,
+      "minifiedJsBytes": 72059,
       "name": "Scientific reader: PNG",
       "recordedBaselineMinifiedBytes": 67385,
-      "brotliBytes": 21108
+      "brotliBytes": 21025
     },
     {
       "category": "purejsimage-entry",
@@ -1153,13 +1153,13 @@
         "packageExports": ["purejsimage/scientific/readers/all"],
         "sourceEntries": ["./src/scientific/readers/all.ts"]
       },
-      "gzipBytes": 358962,
+      "gzipBytes": 358826,
       "id": "scientific-readers-all",
       "implementation": "package-core",
-      "minifiedJsBytes": 1240645,
+      "minifiedJsBytes": 1240347,
       "name": "Scientific readers: all",
       "recordedBaselineMinifiedBytes": 844813,
-      "brotliBytes": 286482
+      "brotliBytes": 286316
     },
     {
       "category": "purejsimage-entry",
@@ -1183,13 +1183,13 @@
         "packageExports": ["purejsimage/codecs/png"],
         "sourceEntries": ["./src/index.ts", "./src/codec-entries/png.ts"]
       },
-      "gzipBytes": 31863,
+      "gzipBytes": 31746,
       "id": "codec-png",
       "implementation": "pure-javascript",
-      "minifiedJsBytes": 96850,
+      "minifiedJsBytes": 96555,
       "name": "Core + PNG",
       "recordedBaselineMinifiedBytes": null,
-      "brotliBytes": 27559
+      "brotliBytes": 27410
     },
     {
       "category": "purejsimage-entry",
@@ -1258,13 +1258,13 @@
         "packageExports": ["purejsimage/codecs/ico"],
         "sourceEntries": ["./src/index.ts", "./src/codec-entries/ico.ts"]
       },
-      "gzipBytes": 34961,
+      "gzipBytes": 34859,
       "id": "codec-ico",
       "implementation": "pure-javascript",
-      "minifiedJsBytes": 106224,
+      "minifiedJsBytes": 105926,
       "name": "Core + ICO",
       "recordedBaselineMinifiedBytes": null,
-      "brotliBytes": 30203
+      "brotliBytes": 30093
     },
     {
       "category": "purejsimage-entry",
@@ -1394,13 +1394,13 @@
         "packageExports": ["purejsimage/codecs/web"],
         "sourceEntries": ["./src/index.ts", "./src/codec-entries/web.ts"]
       },
-      "gzipBytes": 229888,
+      "gzipBytes": 229781,
       "id": "codecs-web",
       "implementation": "pure-javascript",
-      "minifiedJsBytes": 622446,
+      "minifiedJsBytes": 622148,
       "name": "Core + common web codecs",
       "recordedBaselineMinifiedBytes": null,
-      "brotliBytes": 192567
+      "brotliBytes": 192469
     },
     {
       "category": "purejsimage-entry",
@@ -1425,13 +1425,13 @@
         "packageExports": ["purejsimage/codecs/all"],
         "sourceEntries": ["./src/index.ts", "./src/codec-entries/all.ts"]
       },
-      "gzipBytes": 313647,
+      "gzipBytes": 313543,
       "id": "codecs-all",
       "implementation": "pure-javascript",
-      "minifiedJsBytes": 891539,
+      "minifiedJsBytes": 891241,
       "name": "Core + all stable codecs",
       "recordedBaselineMinifiedBytes": null,
-      "brotliBytes": 258563
+      "brotliBytes": 258491
     },
     {
       "category": "competitor",
@@ -1440,13 +1440,13 @@
       "entry": {
         "packageExports": ["purejsimage"]
       },
-      "gzipBytes": 54123,
+      "gzipBytes": 54024,
       "id": "purejsimage-matched",
       "implementation": "pure-javascript",
-      "minifiedJsBytes": 168511,
+      "minifiedJsBytes": 168213,
       "name": "PureJsImage (matched)",
       "recordedBaselineMinifiedBytes": null,
-      "brotliBytes": 44983
+      "brotliBytes": 44896
     },
     {
       "category": "competitor",
@@ -1470,13 +1470,13 @@
       "entry": {
         "packageExports": ["purejsimage/codecs/all"]
       },
-      "gzipBytes": 313647,
+      "gzipBytes": 313543,
       "id": "purejsimage-all",
       "implementation": "pure-javascript",
-      "minifiedJsBytes": 891539,
+      "minifiedJsBytes": 891241,
       "name": "PureJsImage (all stable codecs)",
       "recordedBaselineMinifiedBytes": null,
-      "brotliBytes": 258563
+      "brotliBytes": 258491
     },
     {
       "category": "competitor",

--- a/src/codecs/png.ts
+++ b/src/codecs/png.ts
@@ -1262,7 +1262,11 @@ const writeChunk = async (sink: ImageSink, type: string, data: Uint8Array): Prom
   await sink.write(uint32Bytes(crc32(encodedType, data)))
 }
 
-const filteredMagnitude = (value: number): number => (value < 128 ? value : 256 - value)
+const filteredMagnitudeTable = Uint8Array.from({ length: 256 }, (_entry, value) =>
+  Math.min(value, 256 - value),
+)
+
+const filteredMagnitude = (value: number): number => filteredMagnitudeTable[value] ?? 0
 
 const chooseAdaptiveFilter = (
   none: number,
@@ -1335,9 +1339,10 @@ const applyFilterScanline = (
   }
 }
 
-const filterScanlineRgb8 = (
+const filterScanline = (
   source: Uint8Array,
   previous: Uint8Array,
+  bytesPerPixel: number,
   output: Uint8Array,
   adaptive: boolean,
 ): void => {
@@ -1349,7 +1354,7 @@ const filterScanlineRgb8 = (
     let average = 0
     let paethScore = 0
     const length = source.byteLength
-    for (let index = 0; index < 3 && index < length; index += 1) {
+    for (let index = 0; index < bytesPerPixel && index < length; index += 1) {
       const value = source[index] ?? 0
       const above = previous[index] ?? 0
       const residual = (value - above) & 0xff
@@ -1359,11 +1364,11 @@ const filterScanlineRgb8 = (
       average += filteredMagnitude((value - Math.floor(above / 2)) & 0xff)
       paethScore += filteredMagnitude(residual)
     }
-    for (let index = 3; index < length; index += 1) {
+    for (let index = bytesPerPixel; index < length; index += 1) {
       const value = source[index] ?? 0
-      const left = source[index - 3] ?? 0
+      const left = source[index - bytesPerPixel] ?? 0
       const above = previous[index] ?? 0
-      const upperLeft = previous[index - 3] ?? 0
+      const upperLeft = previous[index - bytesPerPixel] ?? 0
       none += filteredMagnitude(value)
       sub += filteredMagnitude((value - left) & 0xff)
       up += filteredMagnitude((value - above) & 0xff)
@@ -1371,53 +1376,6 @@ const filterScanlineRgb8 = (
       paethScore += filteredMagnitude((value - paeth(left, above, upperLeft)) & 0xff)
     }
     filter = chooseAdaptiveFilter(none, sub, up, average, paethScore)
-  }
-  applyFilterScanline(source, previous, 3, output, filter)
-}
-
-const filterScanline = (
-  source: Uint8Array,
-  previous: Uint8Array,
-  bytesPerPixel: number,
-  output: Uint8Array,
-  adaptive: boolean,
-): void => {
-  if (bytesPerPixel === 3) {
-    filterScanlineRgb8(source, previous, output, adaptive)
-    return
-  }
-  let filter = 0
-  if (adaptive) {
-    let none = 0
-    let sub = 0
-    let up = 0
-    let average = 0
-    let paethScore = 0
-    for (let index = 0; index < source.byteLength; index += 1) {
-      const value = source[index] ?? 0
-      const left = index >= bytesPerPixel ? (source[index - bytesPerPixel] ?? 0) : 0
-      const above = previous[index] ?? 0
-      const upperLeft = index >= bytesPerPixel ? (previous[index - bytesPerPixel] ?? 0) : 0
-      none += filteredMagnitude(value)
-      sub += filteredMagnitude((value - left) & 0xff)
-      up += filteredMagnitude((value - above) & 0xff)
-      average += filteredMagnitude((value - Math.floor((left + above) / 2)) & 0xff)
-      paethScore += filteredMagnitude((value - paeth(left, above, upperLeft)) & 0xff)
-    }
-    let score = none
-    if (sub < score) {
-      filter = 1
-      score = sub
-    }
-    if (up < score) {
-      filter = 2
-      score = up
-    }
-    if (average < score) {
-      filter = 3
-      score = average
-    }
-    if (paethScore < score) filter = 4
   }
   applyFilterScanline(source, previous, bytesPerPixel, output, filter)
 }


### PR DESCRIPTION

## Summary

Improve PNG encode performance by reducing work in adaptive filter scoring:

- split scanline scoring into a short prefix and branch-free body
- remove the redundant RGB-specific scoring implementation
- replace residual-magnitude arithmetic with a 256-entry lookup table
- preserve identical encoded output and public behavior
- refresh generated package-size documentation
- document all retained and rejected hillclimb experiments

## Performance

Primary workload: `png-resize-1000`, measured against `origin/main` over 15 paired trials.

| Metric | Base | Candidate | Change |
| --- | ---: | ---: | ---: |
| Median wall time | 438.16 ms | 432.26 ms | **-1.35%** |
| Peak RSS | — | — | **-0.05%** |
| Core + PNG minified | 96,850 B | 96,555 B | **-295 B** |

The paired median improvement was **1.06%**, with the candidate faster in **13 of 15** pairs. Output bytes remained identical.

One candidate resize specialization achieved a larger **6.07%** improvement, but was rejected because it exceeded the core bundle-size ceiling.

## Neighboring workloads

- `png-alpha-resize`: **+0.07%**
- `jpeg-to-png`: **+0.70%**, below the 5% regression guard
- output bytes remained exact in both workloads

## Validation

- `npm run check`
- focused PNG, PNG compatibility, and resize tests: **71 passed**
- Imazen PNG corpus: **162 passed, 14 safely rejected, zero failures**
- `npm run browser:check`
- focused Playwright Chromium PNG decode/resize/encode test

The complete optimization campaign and reproduction artifacts are recorded in `benchmark/optimization-log.md`.