### PR TITLE
perf(tiff,resize): 45% faster and 24% lower peak RSS on the large TIFF resize-to-JPEG workload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to PureJsImage are documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- Streaming resize now skips the Lanczos resample stage when the exact-integer box shrink already
+  lands on the requested geometry, uses a specialized unrolled integer kernel for the common rgb8
+  factor-4 shrink, and consumes decoder blocks directly instead of an async per-row iterator.
+  Output bytes are unchanged. Seven paired isolated-process trials of the 4000x3000 TIFF to 1000px
+  JPEG benchmark improved the wall median from 68.29 ms to 37.51 ms (-45.1%) and peak RSS from
+  280 MiB to 214 MiB (-23.7%); the 4000x3000 PNG resize improved by 8.8% and the 1600x2000 WebP to
+  JPEG conversion by 7.7% with identical outputs.
+- The TIFF decoder no longer makes an intermediate whole-span copy when prefetching encoded
+  segments, and uncompressed segments reuse the cache-owned buffer directly unless fill-order
+  reversal or a predictor mutates rows in place. Imazen TIFF corpus outcomes are unchanged
+  (148 pass / 2 unsupported / 4 rejected-safely, zero failures).
+
 ## [0.17.0] - 2026-08-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -80,15 +80,15 @@ PureJsImage 0.17.0 is a zero-runtime-dependency strict TypeScript image-processi
 
 | Current measured surface | Minified JS | gzip | Brotli |
 | --- | ---: | ---: | ---: |
-| Core API | 62.6 KiB | 19.6 KiB | 17.3 KiB |
-| Common web codecs | 612.5 KiB | 226.0 KiB | 189.4 KiB |
-| All stable codecs | 875.4 KiB | 307.8 KiB | 253.8 KiB |
-| Scientific platform | 162.5 KiB | 46.8 KiB | 39.8 KiB |
-| All scientific readers | 1233.9 KiB | 356.9 KiB | 284.7 KiB |
+| Core API | 63.6 KiB | 20.0 KiB | 17.6 KiB |
+| Common web codecs | 613.5 KiB | 226.5 KiB | 190.0 KiB |
+| All stable codecs | 876.4 KiB | 308.4 KiB | 254.1 KiB |
+| Scientific platform | 163.5 KiB | 47.1 KiB | 40.0 KiB |
+| All scientific readers | 1233.9 KiB | 357.0 KiB | 284.8 KiB |
 | Geo raster platform | 136.9 KiB | 37.1 KiB | 31.7 KiB |
-| All Geo readers | 612.5 KiB | 185.4 KiB | 150.1 KiB |
+| All Geo readers | 612.5 KiB | 185.5 KiB | 150.2 KiB |
 
-The extracted npm package is 6.3 MiB with 1 production package. This is unpacked size, not the compressed npm tarball.
+The extracted npm package is 6.4 MiB with 1 production package. This is unpacked size, not the compressed npm tarball.
 <!-- documentation:summary:end -->
 
 ## Install
@@ -362,13 +362,13 @@ Generated for purejsimage 0.17.0. The README keeps only the major entry points; 
 
 | Surface | Import | Minified JS | gzip | Brotli |
 | --- | --- | ---: | ---: | ---: |
-| Core API | `purejsimage` | 62.6 KiB | 19.6 KiB | 17.3 KiB |
-| Core + common web codecs | `purejsimage/codecs/web` | 612.5 KiB | 226.0 KiB | 189.4 KiB |
-| Core + all stable codecs | `purejsimage/codecs/all` | 875.4 KiB | 307.8 KiB | 253.8 KiB |
-| Core + scientific platform | `purejsimage/scientific` | 162.5 KiB | 46.8 KiB | 39.8 KiB |
-| Scientific readers: all | `purejsimage/scientific/readers/all` | 1233.9 KiB | 356.9 KiB | 284.7 KiB |
+| Core API | `purejsimage` | 63.6 KiB | 20.0 KiB | 17.6 KiB |
+| Core + common web codecs | `purejsimage/codecs/web` | 613.5 KiB | 226.5 KiB | 190.0 KiB |
+| Core + all stable codecs | `purejsimage/codecs/all` | 876.4 KiB | 308.4 KiB | 254.1 KiB |
+| Core + scientific platform | `purejsimage/scientific` | 163.5 KiB | 47.1 KiB | 40.0 KiB |
+| Scientific readers: all | `purejsimage/scientific/readers/all` | 1233.9 KiB | 357.0 KiB | 284.8 KiB |
 
-The extracted npm package is 6.3 MiB and has 1 production package. The eight optional JPEG, PNG, and WebP accelerator assets total 175.7 KiB raw WASM and are loaded only through explicit accelerator imports.
+The extracted npm package is 6.4 MiB and has 1 production package. The eight optional JPEG, PNG, and WebP accelerator assets total 175.7 KiB raw WASM and are loaded only through explicit accelerator imports.
 
 [Complete size and footprint tables →](https://purejsimage.com/performance/#package-footprint) · [Machine-readable package metrics](benchmark/generated/package-metrics.json)
 <!-- package-metrics:bundle:end -->

--- a/benchmark/generated/package-metrics.json
+++ b/benchmark/generated/package-metrics.json
@@ -176,7 +176,7 @@
   "package": {
     "name": "purejsimage",
     "version": "0.17.0",
-    "unpackedPackageBytes": 6657702,
+    "unpackedPackageBytes": 6662893,
     "productionPackageCount": 1
   },
   "schemaVersion": 3,
@@ -523,13 +523,13 @@
         "packageExports": ["purejsimage"],
         "sourceEntries": ["./src/index.ts"]
       },
-      "gzipBytes": 20092,
+      "gzipBytes": 20439,
       "id": "core",
       "implementation": "package-core",
-      "minifiedJsBytes": 64127,
+      "minifiedJsBytes": 65144,
       "name": "Core API",
       "recordedBaselineMinifiedBytes": null,
-      "brotliBytes": 17729
+      "brotliBytes": 18024
     },
     {
       "category": "purejsimage-entry",
@@ -538,13 +538,13 @@
         "packageExports": ["purejsimage/scientific"],
         "sourceEntries": ["./src/index.ts", "./src/scientific/index.ts"]
       },
-      "gzipBytes": 47872,
+      "gzipBytes": 48215,
       "id": "scientific",
       "implementation": "package-core",
-      "minifiedJsBytes": 166376,
+      "minifiedJsBytes": 167393,
       "name": "Core + scientific platform",
       "recordedBaselineMinifiedBytes": 143546,
-      "brotliBytes": 40739
+      "brotliBytes": 41009
     },
     {
       "category": "purejsimage-entry",
@@ -568,13 +568,13 @@
         "packageExports": ["purejsimage/geo/readers/all"],
         "sourceEntries": ["./src/geo/readers/all.ts"]
       },
-      "gzipBytes": 189889,
+      "gzipBytes": 189906,
       "id": "geo-readers-all",
       "implementation": "package-core",
-      "minifiedJsBytes": 627173,
+      "minifiedJsBytes": 627208,
       "name": "Geo readers: all",
       "recordedBaselineMinifiedBytes": 626956,
-      "brotliBytes": 153750
+      "brotliBytes": 153839
     },
     {
       "category": "purejsimage-entry",
@@ -898,13 +898,13 @@
         "packageExports": ["purejsimage/scientific/readers/tiff"],
         "sourceEntries": ["./src/scientific/readers/tiff.ts"]
       },
-      "gzipBytes": 103738,
+      "gzipBytes": 103761,
       "id": "scientific-reader-tiff",
       "implementation": "package-core",
-      "minifiedJsBytes": 330801,
+      "minifiedJsBytes": 330836,
       "name": "Scientific reader: TIFF",
       "recordedBaselineMinifiedBytes": 262942,
-      "brotliBytes": 86300
+      "brotliBytes": 86363
     },
     {
       "category": "purejsimage-entry",
@@ -913,13 +913,13 @@
         "packageExports": ["purejsimage/scientific/readers/ome-tiff"],
         "sourceEntries": ["./src/scientific/readers/ome-tiff.ts"]
       },
-      "gzipBytes": 94254,
+      "gzipBytes": 94270,
       "id": "scientific-reader-ome-tiff",
       "implementation": "package-core",
-      "minifiedJsBytes": 299172,
+      "minifiedJsBytes": 299207,
       "name": "Scientific reader: OME-TIFF",
       "recordedBaselineMinifiedBytes": 267489,
-      "brotliBytes": 78243
+      "brotliBytes": 78277
     },
     {
       "category": "purejsimage-entry",
@@ -943,13 +943,13 @@
         "packageExports": ["purejsimage/scientific/readers/aperio-svs"],
         "sourceEntries": ["./src/scientific/readers/aperio-svs.ts"]
       },
-      "gzipBytes": 91484,
+      "gzipBytes": 91502,
       "id": "scientific-reader-aperio-svs",
       "implementation": "package-core",
-      "minifiedJsBytes": 292068,
+      "minifiedJsBytes": 292103,
       "name": "Scientific reader: Aperio SVS",
       "recordedBaselineMinifiedBytes": 259477,
-      "brotliBytes": 75966
+      "brotliBytes": 75987
     },
     {
       "category": "purejsimage-entry",
@@ -1183,13 +1183,13 @@
         "packageExports": ["purejsimage/scientific/readers/all"],
         "sourceEntries": ["./src/scientific/readers/all.ts"]
       },
-      "gzipBytes": 365506,
+      "gzipBytes": 365520,
       "id": "scientific-readers-all",
       "implementation": "package-core",
-      "minifiedJsBytes": 1263471,
+      "minifiedJsBytes": 1263506,
       "name": "Scientific readers: all",
       "recordedBaselineMinifiedBytes": 844813,
-      "brotliBytes": 291546
+      "brotliBytes": 291652
     },
     {
       "category": "purejsimage-entry",
@@ -1198,13 +1198,13 @@
         "packageExports": ["purejsimage/codecs/jpeg"],
         "sourceEntries": ["./src/index.ts", "./src/codec-entries/jpeg.ts"]
       },
-      "gzipBytes": 46161,
+      "gzipBytes": 46506,
       "id": "codec-jpeg",
       "implementation": "pure-javascript",
-      "minifiedJsBytes": 144814,
+      "minifiedJsBytes": 145834,
       "name": "Core + JPEG",
       "recordedBaselineMinifiedBytes": null,
-      "brotliBytes": 38655
+      "brotliBytes": 38952
     },
     {
       "category": "purejsimage-entry",
@@ -1213,13 +1213,13 @@
         "packageExports": ["purejsimage/codecs/png"],
         "sourceEntries": ["./src/index.ts", "./src/codec-entries/png.ts"]
       },
-      "gzipBytes": 32383,
+      "gzipBytes": 32718,
       "id": "codec-png",
       "implementation": "pure-javascript",
-      "minifiedJsBytes": 99243,
+      "minifiedJsBytes": 100260,
       "name": "Core + PNG",
       "recordedBaselineMinifiedBytes": null,
-      "brotliBytes": 27975
+      "brotliBytes": 28245
     },
     {
       "category": "purejsimage-entry",
@@ -1228,13 +1228,13 @@
         "packageExports": ["purejsimage/codecs/webp"],
         "sourceEntries": ["./src/index.ts", "./src/codec-entries/webp.ts"]
       },
-      "gzipBytes": 48651,
+      "gzipBytes": 49007,
       "id": "codec-webp",
       "implementation": "pure-javascript",
-      "minifiedJsBytes": 142330,
+      "minifiedJsBytes": 143350,
       "name": "Core + WebP",
       "recordedBaselineMinifiedBytes": null,
-      "brotliBytes": 41598
+      "brotliBytes": 41916
     },
     {
       "category": "purejsimage-entry",
@@ -1243,13 +1243,13 @@
         "packageExports": ["purejsimage/codecs/bmp"],
         "sourceEntries": ["./src/index.ts", "./src/codec-entries/bmp.ts"]
       },
-      "gzipBytes": 23745,
+      "gzipBytes": 24075,
       "id": "codec-bmp",
       "implementation": "pure-javascript",
-      "minifiedJsBytes": 73984,
+      "minifiedJsBytes": 75001,
       "name": "Core + BMP",
       "recordedBaselineMinifiedBytes": null,
-      "brotliBytes": 20828
+      "brotliBytes": 21069
     },
     {
       "category": "purejsimage-entry",
@@ -1258,13 +1258,13 @@
         "packageExports": ["purejsimage/codecs/tiff"],
         "sourceEntries": ["./src/index.ts", "./src/codec-entries/tiff.ts"]
       },
-      "gzipBytes": 103327,
+      "gzipBytes": 103709,
       "id": "codec-tiff",
       "implementation": "pure-javascript",
-      "minifiedJsBytes": 330538,
+      "minifiedJsBytes": 331597,
       "name": "Core + TIFF",
       "recordedBaselineMinifiedBytes": null,
-      "brotliBytes": 85698
+      "brotliBytes": 85964
     },
     {
       "category": "purejsimage-entry",
@@ -1273,13 +1273,13 @@
         "packageExports": ["purejsimage/codecs/gif"],
         "sourceEntries": ["./src/index.ts", "./src/codec-entries/gif.ts"]
       },
-      "gzipBytes": 22974,
+      "gzipBytes": 23322,
       "id": "codec-gif",
       "implementation": "pure-javascript",
-      "minifiedJsBytes": 72202,
+      "minifiedJsBytes": 73223,
       "name": "Core + GIF",
       "recordedBaselineMinifiedBytes": null,
-      "brotliBytes": 20206
+      "brotliBytes": 20437
     },
     {
       "category": "purejsimage-entry",
@@ -1288,13 +1288,13 @@
         "packageExports": ["purejsimage/codecs/ico"],
         "sourceEntries": ["./src/index.ts", "./src/codec-entries/ico.ts"]
       },
-      "gzipBytes": 35488,
+      "gzipBytes": 35822,
       "id": "codec-ico",
       "implementation": "pure-javascript",
-      "minifiedJsBytes": 108618,
+      "minifiedJsBytes": 109635,
       "name": "Core + ICO",
       "recordedBaselineMinifiedBytes": null,
-      "brotliBytes": 30679
+      "brotliBytes": 30931
     },
     {
       "category": "purejsimage-entry",
@@ -1303,13 +1303,13 @@
         "packageExports": ["purejsimage/codecs/jpeg2000"],
         "sourceEntries": ["./src/index.ts", "./src/codec-entries/jpeg2000.ts"]
       },
-      "gzipBytes": 39334,
+      "gzipBytes": 39656,
       "id": "codec-jpeg2000",
       "implementation": "pure-javascript",
-      "minifiedJsBytes": 124447,
+      "minifiedJsBytes": 125464,
       "name": "Core + JPEG 2000 / JP2",
       "recordedBaselineMinifiedBytes": null,
-      "brotliBytes": 34063
+      "brotliBytes": 34266
     },
     {
       "category": "purejsimage-entry",
@@ -1318,13 +1318,13 @@
         "packageExports": ["purejsimage/codecs/avif"],
         "sourceEntries": ["./src/index.ts", "./src/codec-entries/avif.ts"]
       },
-      "gzipBytes": 176892,
+      "gzipBytes": 177427,
       "id": "codec-avif",
       "implementation": "pure-javascript",
-      "minifiedJsBytes": 464677,
+      "minifiedJsBytes": 465697,
       "name": "Core + AVIF",
       "recordedBaselineMinifiedBytes": null,
-      "brotliBytes": 151231
+      "brotliBytes": 151294
     },
     {
       "category": "purejsimage-entry",
@@ -1333,13 +1333,13 @@
         "packageExports": ["purejsimage/codecs/experimental/heic"],
         "sourceEntries": ["./src/index.ts", "./src/codec-entries/experimental/heic.ts"]
       },
-      "gzipBytes": 52903,
+      "gzipBytes": 53243,
       "id": "codec-heif",
       "implementation": "pure-javascript",
-      "minifiedJsBytes": 164739,
+      "minifiedJsBytes": 165759,
       "name": "Core + HEIF / HEIC (experimental)",
       "recordedBaselineMinifiedBytes": null,
-      "brotliBytes": 45583
+      "brotliBytes": 45764
     },
     {
       "category": "purejsimage-entry",
@@ -1348,13 +1348,13 @@
         "packageExports": ["purejsimage/codecs/jpegxl"],
         "sourceEntries": ["./src/index.ts", "./src/codec-entries/jpegxl.ts"]
       },
-      "gzipBytes": 33139,
+      "gzipBytes": 33471,
       "id": "codec-jpegxl",
       "implementation": "pure-javascript",
-      "minifiedJsBytes": 104716,
+      "minifiedJsBytes": 105733,
       "name": "Core + JPEG XL",
       "recordedBaselineMinifiedBytes": null,
-      "brotliBytes": 28972
+      "brotliBytes": 29195
     },
     {
       "category": "purejsimage-entry",
@@ -1363,13 +1363,13 @@
         "packageExports": ["purejsimage/codecs/hdr"],
         "sourceEntries": ["./src/index.ts", "./src/codec-entries/hdr.ts"]
       },
-      "gzipBytes": 23470,
+      "gzipBytes": 23799,
       "id": "codec-hdr",
       "implementation": "pure-javascript",
-      "minifiedJsBytes": 74231,
+      "minifiedJsBytes": 75248,
       "name": "Core + Radiance HDR / RGBE",
       "recordedBaselineMinifiedBytes": null,
-      "brotliBytes": 20516
+      "brotliBytes": 20768
     },
     {
       "category": "purejsimage-entry",
@@ -1378,13 +1378,13 @@
         "packageExports": ["purejsimage/codecs/qoi"],
         "sourceEntries": ["./src/index.ts", "./src/codec-entries/qoi.ts"]
       },
-      "gzipBytes": 22435,
+      "gzipBytes": 22782,
       "id": "codec-qoi",
       "implementation": "pure-javascript",
-      "minifiedJsBytes": 70732,
+      "minifiedJsBytes": 71749,
       "name": "Core + QOI",
       "recordedBaselineMinifiedBytes": null,
-      "brotliBytes": 19671
+      "brotliBytes": 20020
     },
     {
       "category": "purejsimage-entry",
@@ -1393,13 +1393,13 @@
         "packageExports": ["purejsimage/codecs/netpbm"],
         "sourceEntries": ["./src/index.ts", "./src/codec-entries/netpbm.ts"]
       },
-      "gzipBytes": 24967,
+      "gzipBytes": 25302,
       "id": "codec-netpbm",
       "implementation": "pure-javascript",
-      "minifiedJsBytes": 79144,
+      "minifiedJsBytes": 80161,
       "name": "Core + Netpbm and PFM",
       "recordedBaselineMinifiedBytes": null,
-      "brotliBytes": 21749
+      "brotliBytes": 22020
     },
     {
       "category": "purejsimage-entry",
@@ -1408,13 +1408,13 @@
         "packageExports": ["purejsimage/codecs/tga"],
         "sourceEntries": ["./src/index.ts", "./src/codec-entries/tga.ts"]
       },
-      "gzipBytes": 23757,
+      "gzipBytes": 24100,
       "id": "codec-tga",
       "implementation": "pure-javascript",
-      "minifiedJsBytes": 74600,
+      "minifiedJsBytes": 75617,
       "name": "Core + TGA / TARGA",
       "recordedBaselineMinifiedBytes": null,
-      "brotliBytes": 20785
+      "brotliBytes": 21132
     },
     {
       "category": "purejsimage-entry",
@@ -1424,13 +1424,13 @@
         "packageExports": ["purejsimage/codecs/web"],
         "sourceEntries": ["./src/index.ts", "./src/codec-entries/web.ts"]
       },
-      "gzipBytes": 231399,
+      "gzipBytes": 231982,
       "id": "codecs-web",
       "implementation": "pure-javascript",
-      "minifiedJsBytes": 627167,
+      "minifiedJsBytes": 628187,
       "name": "Core + common web codecs",
       "recordedBaselineMinifiedBytes": null,
-      "brotliBytes": 193948
+      "brotliBytes": 194564
     },
     {
       "category": "purejsimage-entry",
@@ -1455,13 +1455,13 @@
         "packageExports": ["purejsimage/codecs/all"],
         "sourceEntries": ["./src/index.ts", "./src/codec-entries/all.ts"]
       },
-      "gzipBytes": 315236,
+      "gzipBytes": 315843,
       "id": "codecs-all",
       "implementation": "pure-javascript",
-      "minifiedJsBytes": 896424,
+      "minifiedJsBytes": 897483,
       "name": "Core + all stable codecs",
       "recordedBaselineMinifiedBytes": null,
-      "brotliBytes": 259869
+      "brotliBytes": 260205
     },
     {
       "category": "competitor",
@@ -1470,13 +1470,13 @@
       "entry": {
         "packageExports": ["purejsimage"]
       },
-      "gzipBytes": 54672,
+      "gzipBytes": 55013,
       "id": "purejsimage-matched",
       "implementation": "pure-javascript",
-      "minifiedJsBytes": 170907,
+      "minifiedJsBytes": 171927,
       "name": "PureJsImage (matched)",
       "recordedBaselineMinifiedBytes": null,
-      "brotliBytes": 45398
+      "brotliBytes": 45754
     },
     {
       "category": "competitor",
@@ -1500,13 +1500,13 @@
       "entry": {
         "packageExports": ["purejsimage/codecs/all"]
       },
-      "gzipBytes": 315236,
+      "gzipBytes": 315843,
       "id": "purejsimage-all",
       "implementation": "pure-javascript",
-      "minifiedJsBytes": 896424,
+      "minifiedJsBytes": 897483,
       "name": "PureJsImage (all stable codecs)",
       "recordedBaselineMinifiedBytes": null,
-      "brotliBytes": 259869
+      "brotliBytes": 260205
     },
     {
       "category": "competitor",
@@ -2051,7 +2051,7 @@
       "gzipBytes": 39223,
       "id": "sharp",
       "implementation": "native-wrapper",
-      "unpackedPackageBytes": 19793828,
+      "unpackedPackageBytes": 19229274,
       "minifiedJsBytes": 131502,
       "name": "Sharp JS wrapper",
       "packageVersions": [
@@ -2060,12 +2060,12 @@
           "version": "1.1.0"
         },
         {
-          "name": "@img/sharp-libvips-linux-x64",
-          "version": "1.3.2"
+          "name": "@img/sharp-darwin-arm64",
+          "version": "0.35.3"
         },
         {
-          "name": "@img/sharp-linux-x64",
-          "version": "0.35.3"
+          "name": "@img/sharp-libvips-darwin-arm64",
+          "version": "1.3.2"
         },
         {
           "name": "detect-libc",

--- a/benchmark/optimization-log.md
+++ b/benchmark/optimization-log.md
@@ -7,6 +7,14 @@ repeat a dead end without new evidence.
 
 ## Current state
 
+- TIFF campaign 2026-08-25 (`tiff-large-resize-jpeg`): retained TIFF-001 identity-resample
+  bypass, TIFF-002 prefetch span-copy removal, TIFF-003 uncompressed segment aliasing,
+  TIFF-005 unrolled rgb8 factor-4 box-shrink kernels, TIFF-006 block-direct box shrink.
+  Cumulative 68.29 → 37.51 ms (−45.08%), peak RSS 280 → 214 MiB (−23.68%), byte-identical
+  output. Neighbors: `png-resize-1000` −8.84%, `webp-large-resize-jpeg` −7.68%,
+  `stress-100mp-downscale` and `png-alpha-resize` neutral. See the TIFF large-resize
+  campaign section at the bottom of this file.
+
 - Primary workload: `png-resize-1000` — 4000x3000 RGBA PNG to 1000px PNG 6.
   Official 522 vs Sharp 263 ms. Goal is end-to-end speed.
 - Profile: `#decodeTypeScript` ~45% (unfilter + per-pixel `convertRow`), CRC-32 ~10%,
@@ -846,3 +854,55 @@ reduces large-transform process RSS, while memory is safer across runtimes and m
 all measured rows. The default policy therefore uses lazy chunked memory without the previous 64
 MiB Node ceiling. Opt-in file setup and later write failures fall back to memory. Local harness:
 `.tmp/temporary-storage-benchmark/{run.ts,worker.ts}`.
+
+## TIFF large-resize campaign - 2026-08-25
+
+Workload: `tiff-large-resize-jpeg` — 4000x3000 uncompressed stripped RGB TIFF (32-row
+strips), resize to 1000x750, JPEG quality 80. Goal is end-to-end speed. This is the
+TIFF representative in the hillclimb `web-codecs` profile; the TIFF family had no prior
+campaign. CPU profile of the official pipeline: resize box-shrink `accumulateBoxRow`
+~36%, `resizedBlocks` vertical accumulate ~9%, JPEG encoder `quantize` ~11% (already
+campaigned), `writeBoxRow` ~5%, `writeContent` ~4%, TIFF `prefetch`/`decode`/
+`decodeSegment` ~9%. Peak ArrayBuffer diagnostics showed ~174 MiB of buffer churn for
+the 36 MiB source: prefetch span copy + per-segment cache slice + uncompressed
+`Uint8Array.from` + block conversion outputs.
+
+| ID | Timestamp (UTC) | Hypothesis / change | Wall median base → candidate (ms) | Speed Δ | Peak RSS Δ | Verdict | Disposition |
+| --- | --- | --- | ---: | ---: | ---: | --- | --- |
+| TIFF-000 | 2026-08-25 04:36 | No-change control: clean `origin/main` against itself. | 68.32 → 68.71 | +0.56% | +7.08% | inconclusive | Control; runner printed rejected on RSS jitter alone (control RSS MAD 10-16 MiB on a ~290 MiB median). Speed MAD 0.29/0.74 ms. Artifact `.tmp/hillclimb/2026-08-25T04-36-23-267Z/`. |
+| TIFF-001 | 2026-08-25 04:38 | Skip the Lanczos resample stage when the box shrink lands exactly on the requested geometry (scale-1 axes collapse to single weight-1.0 samples under the 1e-12 cutoff, so the stage is byte-exact identity). | 67.98 → 57.97 | **-14.73%** | +10.25% | promising | Retained pending RSS diagnosis. 7/7 pairs faster; output JPEG SHA-256 byte-identical to base. Candidate RSS consistently ~+30 MiB (MAD ~1-2 MiB): isolated diagnostics show identical decode allocations but peak ArrayBuffers 132.9 → 174.3 MiB because the faster run garbage-collects less often. Follow-up experiments target the underlying TIFF copy churn. Artifact `.tmp/hillclimb/2026-08-25T04-38-15-180Z/`. |
+| TIFF-002 | 2026-08-25 04:43 | Drop the intermediate whole-span `Uint8Array.from` copy in the TIFF encoded-segment `prefetch`; the per-segment `slice` already copies into cache-owned buffers. | 67.57 → 52.88 | **-21.73%** | **-11.67%** | material | Retained (cumulative with TIFF-001 vs origin/main). 7/7 pairs faster, paired median -22.41% (MAD 0.16%); candidate RSS 243-253 MiB vs base 256-295 MiB. 79 TIFF tests passed. Artifact `.tmp/hillclimb/2026-08-25T04-43-47-963Z/`. |
+| TIFF-003 | 2026-08-25 04:44 | Return the cache-owned buffer directly for uncompressed TIFF segments; copy only when fill-order reversal or a predictor mutates in place. | 67.81 → 51.24 | **-24.43%** | **-19.07%** | material | Retained (cumulative 001+002+003 vs origin/main). 7/7 pairs faster, paired median -25.29%; RSS 268 → 217 MiB. 92 TIFF+resize tests passed. Artifact `.tmp/hillclimb/2026-08-25T04-44-52-559Z/`. |
+| TIFF-004 | 2026-08-25 04:47 | Generic integer box-shrink accumulate (Uint32 sums, running offsets, dynamic inner trip count) behind a `factorX * factorY <= 65536` guard. | 68.49 → 51.26 | -25.15% cumulative (~0% vs TIFF-003 stack) | -23.60% | neutral | Reverted. Candidate median 51.26 vs prior stack 51.24 ms; warm loop unchanged. Micro-benchmark showed the generic int loop is slower than the Float64 loop (20.7 vs 15.0 ms/image); the win needs a constant trip count. Artifact `.tmp/hillclimb/2026-08-25T04-47-14-453Z/`, micro `.tmp/profile/box-micro.mjs`. |
+| TIFF-005 | 2026-08-25 04:51 | Specialized monomorphic rgb8 factor-4 box-shrink kernels: fully unrolled 12-byte accumulate into Uint32 sums plus a matching write kernel. Micro-benchmark 14.8 → 11.6 ms/image vs the generic float kernel; generic/polymorphic variants regressed. | 67.59 → 38.07 | **-43.68%** | **-22.87%** | material | Retained (cumulative 001+002+003+005 vs origin/main). 7/7 pairs faster; output JPEG SHA-256 byte-identical; 92 TIFF+resize tests passed. Artifact `.tmp/hillclimb/2026-08-25T04-51-09-670Z/`. |
+| TIFF-006 | 2026-08-25 04:53 | Iterate input blocks directly in `boxShrinkBlocks` and process rows synchronously, removing the per-row async iterator (one microtask hop per source row). | 68.29 → 37.51 | **-45.08%** | **-23.68%** | promising | Retained (cumulative vs origin/main). Incremental vs TIFF-005 stack ~-1.5% (candidate medians 38.07 → 37.51, MAD 0.16 both runs); 7/7 pairs faster vs base; 104 resize+TIFF+PNG tests passed. Artifact `.tmp/hillclimb/2026-08-25T04-53-40-533Z/`. |
+
+### TIFF campaign validation and current state
+
+- Cumulative retained stack (TIFF-001+002+003+005+006) vs `origin/main` a54e645:
+  `tiff-large-resize-jpeg` wall median 68.29 → 37.51 ms (**-45.08%**), paired median
+  -45.07% (7/7 pairs), peak RSS 280 → 214 MiB (**-23.68%**). Output JPEG SHA-256 is
+  byte-identical to base. Artifact `.tmp/hillclimb/2026-08-25T04-53-40-533Z/`.
+- Neighbor `png-resize-1000`: 250.5 → 228.3 ms (-8.84%), RSS -3.87%, 7/7 pairs,
+  accepted; the identity-resample bypass also applies to the rgba8 factor-4 shrink.
+  Artifact `.tmp/hillclimb/2026-08-25T04-57-10-096Z/`.
+- Neighbor `stress-100mp-downscale`: 665.0 → 663.6 ms (-0.22%), RSS +0.10%, neutral;
+  its factor-8 shrink stays on the unchanged generic float kernels.
+  Artifact `.tmp/hillclimb/2026-08-25T04-57-39-115Z/`.
+- Neighbor `webp-large-resize-jpeg`: 192.6 → 177.8 ms (-7.68%), RSS -0.41%, 7/7
+  pairs, accepted; 1600x2000 → 800 is an exact factor-2 shrink, so the bypass applies.
+  Artifact `.tmp/hillclimb/2026-08-25T04-58-33-103Z/`.
+- Neighbor `png-alpha-resize`: 34.9 → 34.8 ms (-0.24%), RSS -0.44%, neutral.
+  Artifact `.tmp/hillclimb/2026-08-25T04-58-50-387Z/`.
+- Imazen TIFF corpus: 154 files, 148 pass / 2 unsupported / 4 rejected-safely, zero
+  decode failures, invalid outputs, raw exceptions, timeouts, crashes, or OOM. Per-file
+  outcomes identical between base and candidate runs (`.tmp/imazen-tiff-base/`,
+  `.tmp/imazen-tiff-large-resize/`).
+- Focused tests added: exact rgb8/rgba8 integral box averages through the bypass,
+  group straddling across input blocks with release accounting, truncated-source
+  errors, and repeat uncompressed TIFF strip decodes without copying or source
+  mutation.
+- Remaining profile after the stack: `accumulateBoxRowRgb8x4` ~19%, JPEG encoder
+  `quantize` ~28% combined (already covered by the JPEG campaign, JPEG-036),
+  TIFF `prefetch`/`decode` ~8%. No untried credible TIFF hotspot above ~5% remains
+  for this workload.

--- a/docs-astro/src/data/documentation-data.json
+++ b/docs-astro/src/data/documentation-data.json
@@ -96,29 +96,29 @@
   },
   "sizes": {
     "allGeoReaders": {
-      "brotliBytes": 153750,
-      "gzipBytes": 189889,
-      "minifiedBytes": 627173
+      "brotliBytes": 153839,
+      "gzipBytes": 189906,
+      "minifiedBytes": 627208
     },
     "allReaders": {
-      "brotliBytes": 291546,
-      "gzipBytes": 365506,
-      "minifiedBytes": 1263471
+      "brotliBytes": 291652,
+      "gzipBytes": 365520,
+      "minifiedBytes": 1263506
     },
     "allStableCodecs": {
-      "brotliBytes": 259869,
-      "gzipBytes": 315236,
-      "minifiedBytes": 896424
+      "brotliBytes": 260205,
+      "gzipBytes": 315843,
+      "minifiedBytes": 897483
     },
     "commonWebCodecs": {
-      "brotliBytes": 193948,
-      "gzipBytes": 231399,
-      "minifiedBytes": 627167
+      "brotliBytes": 194564,
+      "gzipBytes": 231982,
+      "minifiedBytes": 628187
     },
     "core": {
-      "brotliBytes": 17729,
-      "gzipBytes": 20092,
-      "minifiedBytes": 64127
+      "brotliBytes": 18024,
+      "gzipBytes": 20439,
+      "minifiedBytes": 65144
     },
     "geoPlatform": {
       "brotliBytes": 32464,
@@ -126,14 +126,14 @@
       "minifiedBytes": 140212
     },
     "installedPackage": {
-      "bytes": 6657702,
+      "bytes": 6662893,
       "productionPackageCount": 1
     },
     "packageVersion": "0.17.0",
     "scientificPlatform": {
-      "brotliBytes": 40739,
-      "gzipBytes": 47872,
-      "minifiedBytes": 166376
+      "brotliBytes": 41009,
+      "gzipBytes": 48215,
+      "minifiedBytes": 167393
     }
   },
   "ordinary": {

--- a/docs-astro/src/data/package-metrics.json
+++ b/docs-astro/src/data/package-metrics.json
@@ -176,7 +176,7 @@
   "package": {
     "name": "purejsimage",
     "version": "0.17.0",
-    "unpackedPackageBytes": 6657702,
+    "unpackedPackageBytes": 6662893,
     "productionPackageCount": 1
   },
   "schemaVersion": 3,
@@ -523,13 +523,13 @@
         "packageExports": ["purejsimage"],
         "sourceEntries": ["./src/index.ts"]
       },
-      "gzipBytes": 20092,
+      "gzipBytes": 20439,
       "id": "core",
       "implementation": "package-core",
-      "minifiedJsBytes": 64127,
+      "minifiedJsBytes": 65144,
       "name": "Core API",
       "recordedBaselineMinifiedBytes": null,
-      "brotliBytes": 17729
+      "brotliBytes": 18024
     },
     {
       "category": "purejsimage-entry",
@@ -538,13 +538,13 @@
         "packageExports": ["purejsimage/scientific"],
         "sourceEntries": ["./src/index.ts", "./src/scientific/index.ts"]
       },
-      "gzipBytes": 47872,
+      "gzipBytes": 48215,
       "id": "scientific",
       "implementation": "package-core",
-      "minifiedJsBytes": 166376,
+      "minifiedJsBytes": 167393,
       "name": "Core + scientific platform",
       "recordedBaselineMinifiedBytes": 143546,
-      "brotliBytes": 40739
+      "brotliBytes": 41009
     },
     {
       "category": "purejsimage-entry",
@@ -568,13 +568,13 @@
         "packageExports": ["purejsimage/geo/readers/all"],
         "sourceEntries": ["./src/geo/readers/all.ts"]
       },
-      "gzipBytes": 189889,
+      "gzipBytes": 189906,
       "id": "geo-readers-all",
       "implementation": "package-core",
-      "minifiedJsBytes": 627173,
+      "minifiedJsBytes": 627208,
       "name": "Geo readers: all",
       "recordedBaselineMinifiedBytes": 626956,
-      "brotliBytes": 153750
+      "brotliBytes": 153839
     },
     {
       "category": "purejsimage-entry",
@@ -898,13 +898,13 @@
         "packageExports": ["purejsimage/scientific/readers/tiff"],
         "sourceEntries": ["./src/scientific/readers/tiff.ts"]
       },
-      "gzipBytes": 103738,
+      "gzipBytes": 103761,
       "id": "scientific-reader-tiff",
       "implementation": "package-core",
-      "minifiedJsBytes": 330801,
+      "minifiedJsBytes": 330836,
       "name": "Scientific reader: TIFF",
       "recordedBaselineMinifiedBytes": 262942,
-      "brotliBytes": 86300
+      "brotliBytes": 86363
     },
     {
       "category": "purejsimage-entry",
@@ -913,13 +913,13 @@
         "packageExports": ["purejsimage/scientific/readers/ome-tiff"],
         "sourceEntries": ["./src/scientific/readers/ome-tiff.ts"]
       },
-      "gzipBytes": 94254,
+      "gzipBytes": 94270,
       "id": "scientific-reader-ome-tiff",
       "implementation": "package-core",
-      "minifiedJsBytes": 299172,
+      "minifiedJsBytes": 299207,
       "name": "Scientific reader: OME-TIFF",
       "recordedBaselineMinifiedBytes": 267489,
-      "brotliBytes": 78243
+      "brotliBytes": 78277
     },
     {
       "category": "purejsimage-entry",
@@ -943,13 +943,13 @@
         "packageExports": ["purejsimage/scientific/readers/aperio-svs"],
         "sourceEntries": ["./src/scientific/readers/aperio-svs.ts"]
       },
-      "gzipBytes": 91484,
+      "gzipBytes": 91502,
       "id": "scientific-reader-aperio-svs",
       "implementation": "package-core",
-      "minifiedJsBytes": 292068,
+      "minifiedJsBytes": 292103,
       "name": "Scientific reader: Aperio SVS",
       "recordedBaselineMinifiedBytes": 259477,
-      "brotliBytes": 75966
+      "brotliBytes": 75987
     },
     {
       "category": "purejsimage-entry",
@@ -1183,13 +1183,13 @@
         "packageExports": ["purejsimage/scientific/readers/all"],
         "sourceEntries": ["./src/scientific/readers/all.ts"]
       },
-      "gzipBytes": 365506,
+      "gzipBytes": 365520,
       "id": "scientific-readers-all",
       "implementation": "package-core",
-      "minifiedJsBytes": 1263471,
+      "minifiedJsBytes": 1263506,
       "name": "Scientific readers: all",
       "recordedBaselineMinifiedBytes": 844813,
-      "brotliBytes": 291546
+      "brotliBytes": 291652
     },
     {
       "category": "purejsimage-entry",
@@ -1198,13 +1198,13 @@
         "packageExports": ["purejsimage/codecs/jpeg"],
         "sourceEntries": ["./src/index.ts", "./src/codec-entries/jpeg.ts"]
       },
-      "gzipBytes": 46161,
+      "gzipBytes": 46506,
       "id": "codec-jpeg",
       "implementation": "pure-javascript",
-      "minifiedJsBytes": 144814,
+      "minifiedJsBytes": 145834,
       "name": "Core + JPEG",
       "recordedBaselineMinifiedBytes": null,
-      "brotliBytes": 38655
+      "brotliBytes": 38952
     },
     {
       "category": "purejsimage-entry",
@@ -1213,13 +1213,13 @@
         "packageExports": ["purejsimage/codecs/png"],
         "sourceEntries": ["./src/index.ts", "./src/codec-entries/png.ts"]
       },
-      "gzipBytes": 32383,
+      "gzipBytes": 32718,
       "id": "codec-png",
       "implementation": "pure-javascript",
-      "minifiedJsBytes": 99243,
+      "minifiedJsBytes": 100260,
       "name": "Core + PNG",
       "recordedBaselineMinifiedBytes": null,
-      "brotliBytes": 27975
+      "brotliBytes": 28245
     },
     {
       "category": "purejsimage-entry",
@@ -1228,13 +1228,13 @@
         "packageExports": ["purejsimage/codecs/webp"],
         "sourceEntries": ["./src/index.ts", "./src/codec-entries/webp.ts"]
       },
-      "gzipBytes": 48651,
+      "gzipBytes": 49007,
       "id": "codec-webp",
       "implementation": "pure-javascript",
-      "minifiedJsBytes": 142330,
+      "minifiedJsBytes": 143350,
       "name": "Core + WebP",
       "recordedBaselineMinifiedBytes": null,
-      "brotliBytes": 41598
+      "brotliBytes": 41916
     },
     {
       "category": "purejsimage-entry",
@@ -1243,13 +1243,13 @@
         "packageExports": ["purejsimage/codecs/bmp"],
         "sourceEntries": ["./src/index.ts", "./src/codec-entries/bmp.ts"]
       },
-      "gzipBytes": 23745,
+      "gzipBytes": 24075,
       "id": "codec-bmp",
       "implementation": "pure-javascript",
-      "minifiedJsBytes": 73984,
+      "minifiedJsBytes": 75001,
       "name": "Core + BMP",
       "recordedBaselineMinifiedBytes": null,
-      "brotliBytes": 20828
+      "brotliBytes": 21069
     },
     {
       "category": "purejsimage-entry",
@@ -1258,13 +1258,13 @@
         "packageExports": ["purejsimage/codecs/tiff"],
         "sourceEntries": ["./src/index.ts", "./src/codec-entries/tiff.ts"]
       },
-      "gzipBytes": 103327,
+      "gzipBytes": 103709,
       "id": "codec-tiff",
       "implementation": "pure-javascript",
-      "minifiedJsBytes": 330538,
+      "minifiedJsBytes": 331597,
       "name": "Core + TIFF",
       "recordedBaselineMinifiedBytes": null,
-      "brotliBytes": 85698
+      "brotliBytes": 85964
     },
     {
       "category": "purejsimage-entry",
@@ -1273,13 +1273,13 @@
         "packageExports": ["purejsimage/codecs/gif"],
         "sourceEntries": ["./src/index.ts", "./src/codec-entries/gif.ts"]
       },
-      "gzipBytes": 22974,
+      "gzipBytes": 23322,
       "id": "codec-gif",
       "implementation": "pure-javascript",
-      "minifiedJsBytes": 72202,
+      "minifiedJsBytes": 73223,
       "name": "Core + GIF",
       "recordedBaselineMinifiedBytes": null,
-      "brotliBytes": 20206
+      "brotliBytes": 20437
     },
     {
       "category": "purejsimage-entry",
@@ -1288,13 +1288,13 @@
         "packageExports": ["purejsimage/codecs/ico"],
         "sourceEntries": ["./src/index.ts", "./src/codec-entries/ico.ts"]
       },
-      "gzipBytes": 35488,
+      "gzipBytes": 35822,
       "id": "codec-ico",
       "implementation": "pure-javascript",
-      "minifiedJsBytes": 108618,
+      "minifiedJsBytes": 109635,
       "name": "Core + ICO",
       "recordedBaselineMinifiedBytes": null,
-      "brotliBytes": 30679
+      "brotliBytes": 30931
     },
     {
       "category": "purejsimage-entry",
@@ -1303,13 +1303,13 @@
         "packageExports": ["purejsimage/codecs/jpeg2000"],
         "sourceEntries": ["./src/index.ts", "./src/codec-entries/jpeg2000.ts"]
       },
-      "gzipBytes": 39334,
+      "gzipBytes": 39656,
       "id": "codec-jpeg2000",
       "implementation": "pure-javascript",
-      "minifiedJsBytes": 124447,
+      "minifiedJsBytes": 125464,
       "name": "Core + JPEG 2000 / JP2",
       "recordedBaselineMinifiedBytes": null,
-      "brotliBytes": 34063
+      "brotliBytes": 34266
     },
     {
       "category": "purejsimage-entry",
@@ -1318,13 +1318,13 @@
         "packageExports": ["purejsimage/codecs/avif"],
         "sourceEntries": ["./src/index.ts", "./src/codec-entries/avif.ts"]
       },
-      "gzipBytes": 176892,
+      "gzipBytes": 177427,
       "id": "codec-avif",
       "implementation": "pure-javascript",
-      "minifiedJsBytes": 464677,
+      "minifiedJsBytes": 465697,
       "name": "Core + AVIF",
       "recordedBaselineMinifiedBytes": null,
-      "brotliBytes": 151231
+      "brotliBytes": 151294
     },
     {
       "category": "purejsimage-entry",
@@ -1333,13 +1333,13 @@
         "packageExports": ["purejsimage/codecs/experimental/heic"],
         "sourceEntries": ["./src/index.ts", "./src/codec-entries/experimental/heic.ts"]
       },
-      "gzipBytes": 52903,
+      "gzipBytes": 53243,
       "id": "codec-heif",
       "implementation": "pure-javascript",
-      "minifiedJsBytes": 164739,
+      "minifiedJsBytes": 165759,
       "name": "Core + HEIF / HEIC (experimental)",
       "recordedBaselineMinifiedBytes": null,
-      "brotliBytes": 45583
+      "brotliBytes": 45764
     },
     {
       "category": "purejsimage-entry",
@@ -1348,13 +1348,13 @@
         "packageExports": ["purejsimage/codecs/jpegxl"],
         "sourceEntries": ["./src/index.ts", "./src/codec-entries/jpegxl.ts"]
       },
-      "gzipBytes": 33139,
+      "gzipBytes": 33471,
       "id": "codec-jpegxl",
       "implementation": "pure-javascript",
-      "minifiedJsBytes": 104716,
+      "minifiedJsBytes": 105733,
       "name": "Core + JPEG XL",
       "recordedBaselineMinifiedBytes": null,
-      "brotliBytes": 28972
+      "brotliBytes": 29195
     },
     {
       "category": "purejsimage-entry",
@@ -1363,13 +1363,13 @@
         "packageExports": ["purejsimage/codecs/hdr"],
         "sourceEntries": ["./src/index.ts", "./src/codec-entries/hdr.ts"]
       },
-      "gzipBytes": 23470,
+      "gzipBytes": 23799,
       "id": "codec-hdr",
       "implementation": "pure-javascript",
-      "minifiedJsBytes": 74231,
+      "minifiedJsBytes": 75248,
       "name": "Core + Radiance HDR / RGBE",
       "recordedBaselineMinifiedBytes": null,
-      "brotliBytes": 20516
+      "brotliBytes": 20768
     },
     {
       "category": "purejsimage-entry",
@@ -1378,13 +1378,13 @@
         "packageExports": ["purejsimage/codecs/qoi"],
         "sourceEntries": ["./src/index.ts", "./src/codec-entries/qoi.ts"]
       },
-      "gzipBytes": 22435,
+      "gzipBytes": 22782,
       "id": "codec-qoi",
       "implementation": "pure-javascript",
-      "minifiedJsBytes": 70732,
+      "minifiedJsBytes": 71749,
       "name": "Core + QOI",
       "recordedBaselineMinifiedBytes": null,
-      "brotliBytes": 19671
+      "brotliBytes": 20020
     },
     {
       "category": "purejsimage-entry",
@@ -1393,13 +1393,13 @@
         "packageExports": ["purejsimage/codecs/netpbm"],
         "sourceEntries": ["./src/index.ts", "./src/codec-entries/netpbm.ts"]
       },
-      "gzipBytes": 24967,
+      "gzipBytes": 25302,
       "id": "codec-netpbm",
       "implementation": "pure-javascript",
-      "minifiedJsBytes": 79144,
+      "minifiedJsBytes": 80161,
       "name": "Core + Netpbm and PFM",
       "recordedBaselineMinifiedBytes": null,
-      "brotliBytes": 21749
+      "brotliBytes": 22020
     },
     {
       "category": "purejsimage-entry",
@@ -1408,13 +1408,13 @@
         "packageExports": ["purejsimage/codecs/tga"],
         "sourceEntries": ["./src/index.ts", "./src/codec-entries/tga.ts"]
       },
-      "gzipBytes": 23757,
+      "gzipBytes": 24100,
       "id": "codec-tga",
       "implementation": "pure-javascript",
-      "minifiedJsBytes": 74600,
+      "minifiedJsBytes": 75617,
       "name": "Core + TGA / TARGA",
       "recordedBaselineMinifiedBytes": null,
-      "brotliBytes": 20785
+      "brotliBytes": 21132
     },
     {
       "category": "purejsimage-entry",
@@ -1424,13 +1424,13 @@
         "packageExports": ["purejsimage/codecs/web"],
         "sourceEntries": ["./src/index.ts", "./src/codec-entries/web.ts"]
       },
-      "gzipBytes": 231399,
+      "gzipBytes": 231982,
       "id": "codecs-web",
       "implementation": "pure-javascript",
-      "minifiedJsBytes": 627167,
+      "minifiedJsBytes": 628187,
       "name": "Core + common web codecs",
       "recordedBaselineMinifiedBytes": null,
-      "brotliBytes": 193948
+      "brotliBytes": 194564
     },
     {
       "category": "purejsimage-entry",
@@ -1455,13 +1455,13 @@
         "packageExports": ["purejsimage/codecs/all"],
         "sourceEntries": ["./src/index.ts", "./src/codec-entries/all.ts"]
       },
-      "gzipBytes": 315236,
+      "gzipBytes": 315843,
       "id": "codecs-all",
       "implementation": "pure-javascript",
-      "minifiedJsBytes": 896424,
+      "minifiedJsBytes": 897483,
       "name": "Core + all stable codecs",
       "recordedBaselineMinifiedBytes": null,
-      "brotliBytes": 259869
+      "brotliBytes": 260205
     },
     {
       "category": "competitor",
@@ -1470,13 +1470,13 @@
       "entry": {
         "packageExports": ["purejsimage"]
       },
-      "gzipBytes": 54672,
+      "gzipBytes": 55013,
       "id": "purejsimage-matched",
       "implementation": "pure-javascript",
-      "minifiedJsBytes": 170907,
+      "minifiedJsBytes": 171927,
       "name": "PureJsImage (matched)",
       "recordedBaselineMinifiedBytes": null,
-      "brotliBytes": 45398
+      "brotliBytes": 45754
     },
     {
       "category": "competitor",
@@ -1500,13 +1500,13 @@
       "entry": {
         "packageExports": ["purejsimage/codecs/all"]
       },
-      "gzipBytes": 315236,
+      "gzipBytes": 315843,
       "id": "purejsimage-all",
       "implementation": "pure-javascript",
-      "minifiedJsBytes": 896424,
+      "minifiedJsBytes": 897483,
       "name": "PureJsImage (all stable codecs)",
       "recordedBaselineMinifiedBytes": null,
-      "brotliBytes": 259869
+      "brotliBytes": 260205
     },
     {
       "category": "competitor",
@@ -2051,7 +2051,7 @@
       "gzipBytes": 39223,
       "id": "sharp",
       "implementation": "native-wrapper",
-      "unpackedPackageBytes": 19793828,
+      "unpackedPackageBytes": 19229274,
       "minifiedJsBytes": 131502,
       "name": "Sharp JS wrapper",
       "packageVersions": [
@@ -2060,12 +2060,12 @@
           "version": "1.1.0"
         },
         {
-          "name": "@img/sharp-libvips-linux-x64",
-          "version": "1.3.2"
+          "name": "@img/sharp-darwin-arm64",
+          "version": "0.35.3"
         },
         {
-          "name": "@img/sharp-linux-x64",
-          "version": "0.35.3"
+          "name": "@img/sharp-libvips-darwin-arm64",
+          "version": "1.3.2"
         },
         {
           "name": "detect-libc",

--- a/src/codecs/tiff.ts
+++ b/src/codecs/tiff.ts
@@ -3162,9 +3162,10 @@ class TiffEncodedCacheSource implements ImageSource {
         spanEnd = nextEnd
         last += 1
       }
-      const span = Uint8Array.from(
-        await readExactly(this.#source, spanStart, spanEnd - spanStart, options),
-      )
+      // readExactly may return a view into the source's memory; the per-item
+      // slice below already copies into cache-owned buffers, so no
+      // intermediate whole-span copy is needed.
+      const span = await readExactly(this.#source, spanStart, spanEnd - spanStart, options)
       for (let spanIndex = index; spanIndex <= last; spanIndex += 1) {
         const item = pending[spanIndex]
         if (item === undefined) continue
@@ -3313,7 +3314,13 @@ const decodeSegment = async (
         `TIFF uncompressed strip has ${encoded.byteLength}, expected ${expectedBytes} bytes`,
       )
     }
-    decoded = Uint8Array.from(encoded)
+    // Copy only when a later in-place step (fill-order reversal or predictor)
+    // would mutate the cached encoded bytes. Conversion reads planes without
+    // writing to them, so the cache-owned buffer can be used directly.
+    decoded =
+      description.fillOrder === 2 || description.predictor === 2 || description.predictor === 3
+        ? Uint8Array.from(encoded)
+        : encoded
   } else if (description.compression === compressionPackBits) {
     decoded = decodePackBits(encoded, expectedBytes)
   } else if (description.compression === compressionLzw) {

--- a/src/resize.ts
+++ b/src/resize.ts
@@ -299,6 +299,58 @@ const boxShrinkFactor = (sourceSize: number, scaledSize: number, kernel: ResizeK
   return factor
 }
 
+// Specialized monomorphic kernel for the common rgb8 factor-4 box shrink.
+// The box factor always divides the source width, so every output pixel
+// reads exactly twelve bytes. Integer sums are exact and match the generic
+// Float64 accumulation byte for byte; the caller guards factorY so
+// 255 * 4 * factorY stays inside Uint32 range.
+const accumulateBoxRowRgb8x4 = (
+  source: Uint8Array,
+  outputWidth: number,
+  sums: Uint32Array,
+): void => {
+  let sourceOffset = 0
+  for (let outputX = 0; outputX < outputWidth; outputX += 1) {
+    const target = outputX * 3
+    sums[target] =
+      (sums[target] ?? 0) +
+      (source[sourceOffset] ?? 0) +
+      (source[sourceOffset + 3] ?? 0) +
+      (source[sourceOffset + 6] ?? 0) +
+      (source[sourceOffset + 9] ?? 0)
+    sums[target + 1] =
+      (sums[target + 1] ?? 0) +
+      (source[sourceOffset + 1] ?? 0) +
+      (source[sourceOffset + 4] ?? 0) +
+      (source[sourceOffset + 7] ?? 0) +
+      (source[sourceOffset + 10] ?? 0)
+    sums[target + 2] =
+      (sums[target + 2] ?? 0) +
+      (source[sourceOffset + 2] ?? 0) +
+      (source[sourceOffset + 5] ?? 0) +
+      (source[sourceOffset + 8] ?? 0) +
+      (source[sourceOffset + 11] ?? 0)
+    sourceOffset += 12
+  }
+}
+
+const writeBoxRowRgb8x4 = (
+  sums: Uint32Array,
+  outputWidth: number,
+  sourceRows: number,
+  output: Uint8Array,
+  outputOffset: number,
+): void => {
+  const area = 4 * sourceRows
+  for (let outputX = 0; outputX < outputWidth; outputX += 1) {
+    const sourceOffset = outputX * 3
+    const target = outputOffset + sourceOffset
+    output[target] = byte((sums[sourceOffset] ?? 0) / area)
+    output[target + 1] = byte((sums[sourceOffset + 1] ?? 0) / area)
+    output[target + 2] = byte((sums[sourceOffset + 2] ?? 0) / area)
+  }
+}
+
 const accumulateBoxRow = (
   source: Uint8Array,
   format: PixelFormat,
@@ -418,67 +470,110 @@ const boxShrinkBlocks = async function* (
   const channelCount = channels(format)
   const outputStride = outputWidth * channelCount
   const blockCapacity = Math.min(outputBlockRows, outputHeight)
-  const sourceRows = rows(input, sourceWidth, sourceHeight, format)[Symbol.asyncIterator]()
-  const sums = new Float64Array(outputStride)
+  const rowBytes = sourceWidth * channelCount
+  // 255 * 4 * factorY must stay inside Uint32 for exact integer sums; 65536
+  // is far beyond any realistic vertical box factor.
+  const rgb8x4 = format === 'rgb8' && factorX === 4 && factorY <= 65_536
+  const integerSums = rgb8x4 ? new Uint32Array(outputStride) : undefined
+  const sums = rgb8x4 ? undefined : new Float64Array(outputStride)
   let block = new Uint8Array(outputStride * blockCapacity)
   let sourceY = 0
+  let rowsInGroup = 0
   let blockHeight = 0
   let blockY = 0
 
-  try {
-    while (sourceY < sourceHeight) {
-      const rowsInGroup = Math.min(factorY, sourceHeight - sourceY)
-      sums.fill(0)
-      for (let row = 0; row < rowsInGroup; row += 1) {
-        const next = await sourceRows.next()
-        if (next.done) throw truncatedInput(`Resize input ended before row ${sourceY + row}`)
-        accumulateBoxRow(next.value, format, sourceWidth, factorX, sums)
+  // Iterating input blocks directly keeps the per-row work synchronous; an
+  // async row iterator costs one microtask hop per source row.
+  for await (const inputBlock of input) {
+    try {
+      if (
+        inputBlock.x !== 0 ||
+        inputBlock.y !== sourceY ||
+        inputBlock.width !== sourceWidth ||
+        inputBlock.height < 1 ||
+        inputBlock.format !== format ||
+        inputBlock.stride < rowBytes ||
+        inputBlock.data.byteLength < inputBlock.stride * (inputBlock.height - 1) + rowBytes
+      ) {
+        throw invalidInput('Resize requires ordered, full-width pixel blocks')
       }
-      writeBoxRow(
-        sums,
-        format,
-        sourceWidth,
-        factorX,
-        rowsInGroup,
-        block,
-        blockHeight * outputStride,
-      )
-      sourceY += rowsInGroup
-      blockHeight += 1
-
-      if (blockHeight === blockCapacity) {
-        yield {
-          x: 0,
-          y: blockY,
-          width: outputWidth,
-          height: blockHeight,
-          stride: outputStride,
-          format,
-          data: block,
+      if (sourceY + inputBlock.height > sourceHeight) {
+        throw invalidInput('Resize requires ordered, full-width pixel blocks')
+      }
+      for (let row = 0; row < inputBlock.height; row += 1) {
+        const source = inputBlock.data.subarray(
+          row * inputBlock.stride,
+          row * inputBlock.stride + rowBytes,
+        )
+        if (rowsInGroup === 0) {
+          integerSums?.fill(0)
+          sums?.fill(0)
         }
-        blockY += blockHeight
-        blockHeight = 0
-        const remaining = outputHeight - blockY
-        if (remaining > 0) block = new Uint8Array(outputStride * Math.min(blockCapacity, remaining))
-      }
-    }
+        if (integerSums !== undefined) {
+          accumulateBoxRowRgb8x4(source, outputWidth, integerSums)
+        } else if (sums !== undefined) {
+          accumulateBoxRow(source, format, sourceWidth, factorX, sums)
+        }
+        sourceY += 1
+        rowsInGroup += 1
+        if (rowsInGroup < factorY && sourceY < sourceHeight) continue
 
-    while (!(await sourceRows.next()).done) {
-      // Drain the decoder so compressed input and checksums are fully validated.
-    }
-    if (blockHeight > 0) {
-      yield {
-        x: 0,
-        y: blockY,
-        width: outputWidth,
-        height: blockHeight,
-        stride: outputStride,
-        format,
-        data: block.subarray(0, outputStride * blockHeight),
+        if (integerSums !== undefined) {
+          writeBoxRowRgb8x4(
+            integerSums,
+            outputWidth,
+            rowsInGroup,
+            block,
+            blockHeight * outputStride,
+          )
+        } else if (sums !== undefined) {
+          writeBoxRow(
+            sums,
+            format,
+            sourceWidth,
+            factorX,
+            rowsInGroup,
+            block,
+            blockHeight * outputStride,
+          )
+        }
+        rowsInGroup = 0
+        blockHeight += 1
+
+        if (blockHeight === blockCapacity) {
+          yield {
+            x: 0,
+            y: blockY,
+            width: outputWidth,
+            height: blockHeight,
+            stride: outputStride,
+            format,
+            data: block,
+          }
+          blockY += blockHeight
+          blockHeight = 0
+          const remaining = outputHeight - blockY
+          if (remaining > 0)
+            block = new Uint8Array(outputStride * Math.min(blockCapacity, remaining))
+        }
       }
+    } finally {
+      inputBlock.release?.()
     }
-  } finally {
-    await sourceRows.return?.(undefined)
+  }
+  if (sourceY !== sourceHeight) {
+    throw truncatedInput(`Resize received ${sourceY} of ${sourceHeight} rows`)
+  }
+  if (blockHeight > 0) {
+    yield {
+      x: 0,
+      y: blockY,
+      width: outputWidth,
+      height: blockHeight,
+      stride: outputStride,
+      format,
+      data: block.subarray(0, outputStride * blockHeight),
+    }
   }
 }
 
@@ -789,6 +884,26 @@ const resizedBlocks = async function* (
   }
 }
 
+const boxShrinkCompletesPlan = (
+  plan: ResizePlan,
+  shrunkWidth: number,
+  shrunkHeight: number,
+  sourceFormat: PixelFormat,
+  outputFormat: PixelFormat,
+): boolean =>
+  plan.scaledWidth === shrunkWidth &&
+  plan.scaledHeight === shrunkHeight &&
+  plan.cropX === 0 &&
+  plan.cropY === 0 &&
+  plan.contentWidth === shrunkWidth &&
+  plan.contentHeight === shrunkHeight &&
+  plan.padX === 0 &&
+  plan.padY === 0 &&
+  plan.canvasWidth === shrunkWidth &&
+  plan.canvasHeight === shrunkHeight &&
+  plan.background === undefined &&
+  outputFormat === sourceFormat
+
 export const createResizeTransform = (
   width: number,
   height: number,
@@ -801,6 +916,14 @@ export const createResizeTransform = (
   const factorY = boxShrinkFactor(height, plan.scaledHeight, plan.kernel)
   const resizedWidth = width / factorX
   const resizedHeight = height / factorY
+  // When the box shrink lands exactly on the requested geometry, the Lanczos
+  // pass would resample at scale 1, where every axis collapses to one
+  // weight-1.0 sample per output pixel (integer-offset lanczos weights fall
+  // under the 1e-12 cutoff). Skipping it is byte-exact and avoids a full
+  // extra traversal of the shrunk image.
+  const shrinkCompletesPlan =
+    (factorX > 1 || factorY > 1) &&
+    boxShrinkCompletesPlan(plan, resizedWidth, resizedHeight, pixelFormat, format)
   return {
     width: plan.canvasWidth,
     height: plan.canvasHeight,
@@ -810,6 +933,7 @@ export const createResizeTransform = (
         factorX === 1 && factorY === 1
           ? blocks
           : boxShrinkBlocks(blocks, width, height, pixelFormat, factorX, factorY)
+      if (shrinkCompletesPlan) return shrunk
       return resizedBlocks(shrunk, resizedWidth, resizedHeight, pixelFormat, plan, format)
     },
   }

--- a/tests/resize.test.ts
+++ b/tests/resize.test.ts
@@ -238,4 +238,160 @@ describe('streaming resize', () => {
 
     expect({ width: output.width, height: output.height }).toEqual({ width: 4, height: 2 })
   })
+
+  it('produces exact box averages for an integral rgb8 downscale', async () => {
+    const width = 16
+    const height = 8
+    const value = (x: number, y: number, channel: number): number =>
+      (x * 31 + y * 17 + channel * 5) % 256
+    const data = new Uint8Array(width * height * 3)
+    for (let y = 0; y < height; y += 1) {
+      for (let x = 0; x < width; x += 1) {
+        for (let channel = 0; channel < 3; channel += 1) {
+          data[(y * width + x) * 3 + channel] = value(x, y, channel)
+        }
+      }
+    }
+    const source = async function* (): AsyncGenerator<PixelBlock> {
+      yield { x: 0, y: 0, width, height, stride: width * 3, format: 'rgb8', data }
+    }
+    const transform = createResizeTransform(width, height, 'rgb8', { width: 4 })
+    expect({ width: transform.width, height: transform.height }).toEqual({ width: 4, height: 2 })
+
+    const blocks: PixelBlock[] = []
+    for await (const block of transform.apply(source())) blocks.push(block)
+    expect(blocks).toHaveLength(1)
+    const output = blocks[0]
+    expect(output?.format).toBe('rgb8')
+    for (let outputY = 0; outputY < 2; outputY += 1) {
+      for (let outputX = 0; outputX < 4; outputX += 1) {
+        for (let channel = 0; channel < 3; channel += 1) {
+          let sum = 0
+          for (let y = outputY * 4; y < outputY * 4 + 4; y += 1) {
+            for (let x = outputX * 4; x < outputX * 4 + 4; x += 1) {
+              sum += value(x, y, channel)
+            }
+          }
+          expect(output?.data[(outputY * 4 + outputX) * 3 + channel]).toBe(Math.round(sum / 16))
+        }
+      }
+    }
+  })
+
+  it('box-shrinks groups that straddle input blocks and releases every block', async () => {
+    const width = 8
+    const height = 8
+    const value = (x: number, y: number, channel: number): number =>
+      (x * 13 + y * 29 + channel * 7) % 256
+    const rowsOf = (firstY: number, rows: number): Uint8Array => {
+      const data = new Uint8Array(width * rows * 3)
+      for (let y = 0; y < rows; y += 1) {
+        for (let x = 0; x < width; x += 1) {
+          for (let channel = 0; channel < 3; channel += 1) {
+            data[(y * width + x) * 3 + channel] = value(x, firstY + y, channel)
+          }
+        }
+      }
+      return data
+    }
+    let releases = 0
+    const release = (): void => {
+      releases += 1
+    }
+    const source = async function* (): AsyncGenerator<PixelBlock> {
+      yield {
+        x: 0,
+        y: 0,
+        width,
+        height: 3,
+        stride: width * 3,
+        format: 'rgb8',
+        data: rowsOf(0, 3),
+        release,
+      }
+      yield {
+        x: 0,
+        y: 3,
+        width,
+        height: 5,
+        stride: width * 3,
+        format: 'rgb8',
+        data: rowsOf(3, 5),
+        release,
+      }
+    }
+    const transform = createResizeTransform(width, height, 'rgb8', { width: 2 })
+    const blocks: PixelBlock[] = []
+    for await (const block of transform.apply(source())) blocks.push(block)
+    expect(releases).toBe(2)
+    expect(blocks).toHaveLength(1)
+    const output = blocks[0]
+    for (let outputY = 0; outputY < 2; outputY += 1) {
+      for (let outputX = 0; outputX < 2; outputX += 1) {
+        for (let channel = 0; channel < 3; channel += 1) {
+          let sum = 0
+          for (let y = outputY * 4; y < outputY * 4 + 4; y += 1) {
+            for (let x = outputX * 4; x < outputX * 4 + 4; x += 1) {
+              sum += value(x, y, channel)
+            }
+          }
+          expect(output?.data[(outputY * 2 + outputX) * 3 + channel]).toBe(Math.round(sum / 16))
+        }
+      }
+    }
+  })
+
+  it('produces exact premultiplied box averages for an integral rgba8 downscale', async () => {
+    const value = (x: number, y: number, channel: number): number =>
+      (x * 19 + y * 23 + channel * 11) % 256
+    const output = await execute(
+      png(8, 8, (x, y) => [value(x, y, 0), value(x, y, 1), value(x, y, 2), value(x, y, 3)]),
+      { width: 2 },
+    )
+    expect({ width: output.width, height: output.height }).toEqual({ width: 2, height: 2 })
+    for (let outputY = 0; outputY < 2; outputY += 1) {
+      for (let outputX = 0; outputX < 2; outputX += 1) {
+        let redAlpha = 0
+        let greenAlpha = 0
+        let blueAlpha = 0
+        let alpha = 0
+        for (let y = outputY * 4; y < outputY * 4 + 4; y += 1) {
+          for (let x = outputX * 4; x < outputX * 4 + 4; x += 1) {
+            const sourceAlpha = value(x, y, 3)
+            redAlpha += value(x, y, 0) * sourceAlpha
+            greenAlpha += value(x, y, 1) * sourceAlpha
+            blueAlpha += value(x, y, 2) * sourceAlpha
+            alpha += sourceAlpha
+          }
+        }
+        expect(pixelAt(output, outputX, outputY)).toEqual([
+          Math.round(redAlpha / alpha),
+          Math.round(greenAlpha / alpha),
+          Math.round(blueAlpha / alpha),
+          Math.round(alpha / 16),
+        ])
+      }
+    }
+  })
+
+  it('reports truncated input when a box-shrunk source ends early', async () => {
+    const source = async function* (): AsyncGenerator<PixelBlock> {
+      yield {
+        x: 0,
+        y: 0,
+        width: 8,
+        height: 4,
+        stride: 24,
+        format: 'rgb8',
+        data: new Uint8Array(8 * 4 * 3),
+      }
+    }
+    const transform = createResizeTransform(8, 8, 'rgb8', { width: 2 })
+    const drain = async (): Promise<void> => {
+      for await (const block of transform.apply(source())) void block
+    }
+    await expect(drain()).rejects.toMatchObject({
+      message: 'Resize received 4 of 8 rows',
+    })
+  })
 })

--- a/tests/tiff.test.ts
+++ b/tests/tiff.test.ts
@@ -1807,6 +1807,29 @@ describe('TIFF codec', () => {
     })
   })
 
+  it('repeats uncompressed strip decodes without copying or mutating source bytes', async () => {
+    const pixels = Uint8Array.of(10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120)
+    const input = tiffFixture({
+      width: 2,
+      height: 2,
+      bitsPerSample: [8, 8, 8],
+      compression: 1,
+      photometric: 2,
+      rowsPerStrip: 1,
+      strips: [pixels.subarray(0, 6), pixels.subarray(6, 12)],
+    })
+    const original = Uint8Array.from(input)
+    if (!tiffCodec.createDecoder) throw new Error('TIFF decoder is unavailable')
+    const source = new MemorySource(input)
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      const decoder = await tiffCodec.createDecoder(source, defaultImageLimits)
+      const decoded: number[] = []
+      for await (const block of decoder.decode()) decoded.push(...block.data)
+      expect(Uint8Array.from(decoded)).toEqual(pixels)
+    }
+    expect(input).toEqual(original)
+  })
+
   it('decodes 16-bit palette indices directly to RGB rows', async () => {
     const colors = 65_536
     const colorMap = new Array<number>(colors * 3).fill(0)


### PR DESCRIPTION
## Problem

`tiff-large-resize-jpeg` (4000x3000 uncompressed stripped RGB TIFF, resize to 1000x750, JPEG quality 80) was the slowest common TIFF workload relative to its work. A CPU profile of the official pipeline showed the resize box-shrink accumulate loop at ~36% of samples, an identity Lanczos resample pass at ~13%, and TIFF segment reads at ~9%. Peak ArrayBuffer diagnostics showed about 174 MiB of buffer churn for the 36 MiB source because the TIFF path copied every strip several times.

## Approach

Five retained changes from a benchmark-hillclimb campaign (`benchmark/optimization-log.md`, TIFF large-resize campaign, IDs TIFF-001 to TIFF-006). All output bytes are unchanged; every change either removes work or removes copies.

1. **TIFF-001, resize:** skip the Lanczos resample stage when the exact-integer box shrink already lands on the requested geometry. At scale 1 every axis collapses to a single weight-1.0 sample (integer-offset lanczos weights fall under the existing 1e-12 cutoff), so the stage is byte-exact identity work. The bypass applies only when the plan has no crop, pad, canvas, background, or format change.
2. **TIFF-002, TIFF decoder:** drop the intermediate whole-span `Uint8Array.from` copy in encoded-segment prefetch. The per-segment `slice` already copies into cache-owned buffers.
3. **TIFF-003, TIFF decoder:** return the cache-owned buffer directly for uncompressed segments. The copy remains only when fill-order reversal or a predictor mutates rows in place. Downstream conversion reads planes without writing to them.
4. **TIFF-005, resize:** specialized monomorphic kernels for the common rgb8 factor-4 box shrink (fully unrolled 12-byte accumulate into Uint32 sums, guarded so `255 * 4 * factorY` stays inside Uint32). A generic integer variant was tried first and rejected as neutral; the win needs the constant trip count (micro-benchmark 14.8 -> 11.6 ms/image, artifacts in the optimization log).
5. **TIFF-006, resize:** iterate decoder blocks directly in the box shrink instead of an async per-row iterator, which cost one microtask hop per source row. Block validation, release accounting, and truncation errors are preserved.

## Results

Measured with the repository hillclimb runner: isolated processes, one warmup, seven alternating base/candidate pairs, base `origin/main` a54e645.

Primary workload `tiff-large-resize-jpeg` (`.tmp/hillclimb/2026-08-25T04-53-40-533Z/`):

| Metric | Base | Candidate | Delta |
| --- | ---: | ---: | ---: |
| Wall median | 68.29 ms | 37.51 ms | **-45.08%** |
| Paired median | | | -45.07% (7/7 pairs faster, MAD 0.35%) |
| Peak RSS median | 280 MiB | 214 MiB | **-23.68%** |

Neighboring workloads on the same stack, all with matching correctness signatures and protected metrics:

| Workload | Base | Candidate | Delta | Peak RSS |
| --- | ---: | ---: | ---: | ---: |
| `png-resize-1000` | 250.5 ms | 228.3 ms | -8.84% (7/7 pairs) | -3.87% |
| `webp-large-resize-jpeg` | 192.6 ms | 177.8 ms | -7.68% (7/7 pairs) | -0.41% |
| `stress-100mp-downscale` | 665.0 ms | 663.6 ms | -0.22% (neutral) | +0.10% |
| `png-alpha-resize` | 34.9 ms | 34.8 ms | -0.24% (neutral) | -0.44% |

The PNG and WebP wins come from the same identity-resample bypass (both are exact integer-factor shrinks). The 100 MP stress case uses the unchanged factor-8 generic kernels and is unaffected.

## Correctness validation

- The primary workload's output JPEG SHA-256 is byte-identical between base and candidate builds.
- Every hillclimb run requires matching correctness signatures, operation semantics, fixture and environment fingerprints, and protected output metrics before acceptance; all retained runs passed 7/7 trials.
- Imazen TIFF corpus (154 files): 148 pass / 2 unsupported / 4 rejected-safely, zero decode failures, invalid outputs, exceptions, timeouts, crashes, or OOM. Per-file outcomes are identical between base and candidate runs.
- New focused tests: exact rgb8 and rgba8 integral box averages through the bypass, box groups straddling input blocks with release accounting, truncated-source errors, and repeated uncompressed TIFF strip decodes without copying or mutating source bytes.
- `npm run check` passes (2083 tests), including `browser:check`.

## Tradeoffs

- The core resize module grows by two specialized kernels and the bypass check; the core API bundle grows about 1.0 KiB minified (62.6 -> 63.6 KiB), within the recorded budgets. Generated package metrics and README size blocks are refreshed in this PR.
- Uncompressed TIFF planes may now alias the decoder's private segment cache instead of a fresh copy. Conversion code reads planes without writing, and the mutating paths (fill order 2, predictors 2 and 3) keep their copy. A regression test covers repeat decodes and source-byte integrity.
- Peak RSS on the primary workload drops 23.7% because two full-image copy streams are gone; the remaining churn is the decoded-block and encode path.

## Reproduction

```sh
npm ci
npm run fixtures:prepare -- tiff-gradient-4000x3000 rgba-gradient-4000x3000 stress-gradient-10000x10000 transparent-logo-1200x480 webp-fbi-portrait-1600x2000
npm run bench:hillclimb -- --suite web --workload tiff-large-resize-jpeg --goal speed --base-ref origin/main
npm run bench:hillclimb -- --suite web --workload png-resize-1000 --goal speed --base-ref origin/main
npm run bench:hillclimb -- --suite web --workload webp-large-resize-jpeg --goal speed --base-ref origin/main
npm run bench:hillclimb -- --suite web --workload stress-100mp-downscale --goal speed --base-ref origin/main
npm run corpus:imazen -- --corpus ../codec-corpus --format tiff --output .tmp/imazen-tiff --timeout-ms 30000 --memory-mb 512 --concurrency 2
npm run check
```
